### PR TITLE
ci: group dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,56 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    groups:
+      next:
+        patterns:
+          - "next"
+          - "eslint-config-next"
+          - "@next/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "postcss"
+      testing:
+        patterns:
+          - "jest"
+          - "jest-*"
+          - "@types/jest"
+          - "@testing-library/*"
+      linting:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+      typescript:
+        patterns:
+          - "typescript"
+          - "ts-node"
+          - "@types/node"
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Dependabot PR がパッケージごとにバラけて出ていたのをエコシステム単位に束ねます。

- `next` / `react` / `tailwind` / `testing` / `linting` / `typescript` を関連パッケージでグループ化（バージョンを揃えて上げたいものが 1 PR に集約される）
- それ以外は `minor-and-patch` グループで一括化。**メジャー更新は個別 PR のまま**で、破壊的変更のレビューは残す
- `github-actions` エコシステムを新規追加。`actions/checkout` など workflow 側の更新も対象になる

## Test plan

- [ ] 次回 Dependabot 実行時にグループ単位で PR が作られることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)