### PR TITLE
feat: add brand directory page at /brands

### DIFF
--- a/app/ClientHome.tsx
+++ b/app/ClientHome.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { motion, AnimatePresence } from 'framer-motion'
+import Link from 'next/link'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useState, useEffect, Suspense } from 'react'
 
@@ -179,9 +180,17 @@ function HomeContent() {
 
           <div className="w-12 h-px bg-primary-400/60 mx-auto mb-5" />
 
-          <p className="text-sm sm:text-base text-lounge-400 dark:text-lounge-500 tracking-wide">
+          <p className="text-sm sm:text-base text-lounge-400 dark:text-lounge-500 tracking-wide mb-6">
             あなただけの特別なフレーバーを見つけよう
           </p>
+
+          <Link
+            href="/brands"
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/70 dark:bg-lounge-900/60 backdrop-blur-sm border border-lounge-200/60 dark:border-lounge-800/50 text-xs font-semibold uppercase tracking-[0.18em] text-lounge-600 dark:text-lounge-300 hover:border-primary-400/60 dark:hover:border-primary-500/40 hover:text-primary-600 dark:hover:text-primary-400 transition-all"
+          >
+            <span>ブランド一覧を見る</span>
+            <span aria-hidden>→</span>
+          </Link>
         </motion.div>
 
         <SearchBar

--- a/app/api/brands/route.ts
+++ b/app/api/brands/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+
+import { shishaData } from '../../../data/shishaData'
+import { getUniqueBrands, normalizeBrandName, normalizeBrandForSearch } from '../../../lib/utils/brandNormalizer'
+
+export interface BrandSummary {
+  name: string
+  count: number
+  sampleFlavors: string[]
+}
+
+export async function GET(): Promise<NextResponse<BrandSummary[]>> {
+  const counts = new Map<string, { displayName: string; count: number; samples: string[] }>()
+
+  for (const item of shishaData) {
+    const key = normalizeBrandForSearch(item.manufacturer)
+    const entry = counts.get(key)
+    if (entry) {
+      entry.count += 1
+      if (entry.samples.length < 3) {
+        entry.samples.push(item.productName)
+      }
+    } else {
+      counts.set(key, {
+        displayName: normalizeBrandName(item.manufacturer),
+        count: 1,
+        samples: [item.productName],
+      })
+    }
+  }
+
+  const uniqueBrands = getUniqueBrands(shishaData.map(i => i.manufacturer))
+  const brands: BrandSummary[] = uniqueBrands.map(name => {
+    const entry = counts.get(normalizeBrandForSearch(name))
+    return {
+      name,
+      count: entry?.count ?? 0,
+      sampleFlavors: entry?.samples ?? [],
+    }
+  })
+
+  return NextResponse.json(brands)
+}

--- a/app/brands/BrandsClient.tsx
+++ b/app/brands/BrandsClient.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+
+import BackgroundOrbs from '../../components/BackgroundOrbs'
+import BrandCard from '../../components/BrandCard'
+import { getBrandImageUrl } from '../../data/brandImages'
+import type { BrandSummary } from '../api/brands/route'
+
+type SortKey = 'alpha' | 'popularity'
+
+interface BrandsClientProps {
+  brands: BrandSummary[]
+}
+
+export default function BrandsClient({ brands }: BrandsClientProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('popularity')
+
+  const filteredBrands = useMemo(() => {
+    const term = searchQuery.trim().toLowerCase()
+    const base = term
+      ? brands.filter(b => b.name.toLowerCase().includes(term))
+      : brands
+    const sorted = [...base]
+    if (sortKey === 'popularity') {
+      sorted.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    } else {
+      sorted.sort((a, b) => a.name.localeCompare(b.name))
+    }
+    return sorted
+  }, [brands, searchQuery, sortKey])
+
+  const totalFlavors = useMemo(
+    () => brands.reduce((sum, b) => sum + b.count, 0),
+    [brands]
+  )
+
+  return (
+    <div className="min-h-screen relative overflow-hidden bg-atmosphere-light dark:bg-atmosphere-dark">
+      <BackgroundOrbs />
+
+      <main className="relative mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-20 max-w-7xl">
+        <motion.div
+          initial={{ opacity: 0, y: -16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94] }}
+          className="text-center mb-12"
+        >
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-lounge-400 dark:text-lounge-500 hover:text-primary-500 dark:hover:text-primary-400 transition-colors mb-6"
+          >
+            <span>←</span>
+            <span>Back to Search</span>
+          </Link>
+
+          <h1
+            className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-normal text-lounge-900 dark:text-lounge-100 mb-4 tracking-tight leading-[0.95]"
+            style={{ fontFamily: 'var(--font-display), serif' }}
+          >
+            Brand <span className="text-gold-gradient">Directory</span>
+          </h1>
+
+          <div className="w-12 h-px bg-primary-400/60 mx-auto mb-5" />
+
+          <p className="text-sm sm:text-base text-lounge-400 dark:text-lounge-500 tracking-wide">
+            {brands.length} ブランド · {totalFlavors.toLocaleString()} フレーバー
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.1 }}
+          className="mb-10 max-w-3xl mx-auto"
+        >
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="relative flex-1">
+              <input
+                type="text"
+                placeholder="ブランド名で検索..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full px-4 py-3 pl-11 bg-white/80 dark:bg-lounge-900/60 backdrop-blur-sm text-lounge-900 dark:text-lounge-100 placeholder-lounge-400 dark:placeholder-lounge-600 rounded-lg border border-lounge-200/60 dark:border-lounge-800/40 focus:border-primary-400/60 dark:focus:border-primary-500/40 focus:outline-none transition-all text-sm"
+              />
+              <MagnifyingGlassIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-lounge-400" />
+            </div>
+
+            <div className="inline-flex rounded-lg bg-white/80 dark:bg-lounge-900/60 backdrop-blur-sm border border-lounge-200/60 dark:border-lounge-800/40 p-1">
+              {(['popularity', 'alpha'] as SortKey[]).map((key) => (
+                <button
+                  key={key}
+                  onClick={() => setSortKey(key)}
+                  className={`px-4 py-2 rounded-md text-xs font-semibold tracking-wide transition-all ${
+                    sortKey === key
+                      ? 'bg-primary-500 text-white shadow-sm'
+                      : 'text-lounge-600 dark:text-lounge-400 hover:text-lounge-900 dark:hover:text-lounge-100'
+                  }`}
+                >
+                  {key === 'popularity' ? '人気順' : 'A–Z'}
+                </button>
+              ))}
+            </div>
+          </div>
+        </motion.div>
+
+        {filteredBrands.length > 0 ? (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-5">
+            {filteredBrands.map((brand, idx) => (
+              <BrandCard
+                key={brand.name}
+                name={brand.name}
+                count={brand.count}
+                sampleFlavors={brand.sampleFlavors}
+                imageUrl={getBrandImageUrl(brand.name)}
+                index={idx}
+              />
+            ))}
+          </div>
+        ) : (
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="text-center py-20"
+          >
+            <div className="w-20 h-20 mx-auto mb-6 border border-lounge-200 dark:border-lounge-700 rounded-full flex items-center justify-center">
+              <MagnifyingGlassIcon className="w-8 h-8 text-lounge-300 dark:text-lounge-600" />
+            </div>
+            <h3
+              className="text-xl font-medium text-lounge-700 dark:text-lounge-300 mb-2"
+              style={{ fontFamily: 'var(--font-display), serif' }}
+            >
+              ブランドが見つかりません
+            </h3>
+            <p className="text-sm text-lounge-400 dark:text-lounge-500">
+              検索条件を変更してもう一度お試しください
+            </p>
+          </motion.div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/app/brands/page.tsx
+++ b/app/brands/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from 'next'
+
+import { shishaData } from '../../data/shishaData'
+import { getUniqueBrands, normalizeBrandForSearch, normalizeBrandName } from '../../lib/utils/brandNormalizer'
+import type { BrandSummary } from '../api/brands/route'
+
+import BrandsClient from './BrandsClient'
+
+export const metadata: Metadata = {
+  title: 'Brand Directory | Shisha Flavor Search',
+  description: '取り扱いシーシャブランドの一覧。ブランドから好みのフレーバーを探しましょう。',
+}
+
+function buildBrandSummaries(): BrandSummary[] {
+  const counts = new Map<string, { displayName: string; count: number; samples: string[] }>()
+
+  for (const item of shishaData) {
+    const key = normalizeBrandForSearch(item.manufacturer)
+    const entry = counts.get(key)
+    if (entry) {
+      entry.count += 1
+      if (entry.samples.length < 3) {
+        entry.samples.push(item.productName)
+      }
+    } else {
+      counts.set(key, {
+        displayName: normalizeBrandName(item.manufacturer),
+        count: 1,
+        samples: [item.productName],
+      })
+    }
+  }
+
+  return getUniqueBrands(shishaData.map(i => i.manufacturer)).map(name => {
+    const entry = counts.get(normalizeBrandForSearch(name))
+    return {
+      name,
+      count: entry?.count ?? 0,
+      sampleFlavors: entry?.samples ?? [],
+    }
+  })
+}
+
+export default function BrandsPage() {
+  const brands = buildBrandSummaries()
+  return <BrandsClient brands={brands} />
+}

--- a/components/BrandCard.tsx
+++ b/components/BrandCard.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useState } from 'react'
+
+interface BrandCardProps {
+  name: string
+  count: number
+  sampleFlavors: string[]
+  imageUrl?: string
+  index?: number
+}
+
+const GRADIENTS = [
+  'from-primary-600 via-accent-500 to-accent-700',
+  'from-accent-700 via-primary-500 to-primary-800',
+  'from-lounge-800 via-accent-600 to-primary-600',
+  'from-primary-700 via-primary-400 to-accent-600',
+  'from-accent-800 via-accent-500 to-primary-400',
+  'from-primary-800 via-accent-700 to-lounge-700',
+  'from-accent-600 via-primary-600 to-primary-900',
+  'from-lounge-700 via-primary-700 to-accent-500',
+]
+
+function hashString(str: string): number {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0
+  }
+  return Math.abs(hash)
+}
+
+function getBrandInitials(name: string): string {
+  const words = name.split(/\s+/).filter(Boolean)
+  if (words.length === 0) return '?'
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase()
+  return (words[0][0] + words[1][0]).toUpperCase()
+}
+
+export default function BrandCard({ name, count, sampleFlavors, imageUrl, index = 0 }: BrandCardProps) {
+  const [imageError, setImageError] = useState(false)
+  const showImage = Boolean(imageUrl) && !imageError
+
+  const gradient = GRADIENTS[hashString(name) % GRADIENTS.length]
+  const initials = getBrandInitials(name)
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: Math.min(index * 0.02, 0.6), duration: 0.4, ease: [0.25, 0.46, 0.45, 0.94] }}
+      whileHover={{ y: -4 }}
+      className="group"
+    >
+      <Link
+        href={`/?manufacturer=${encodeURIComponent(name)}`}
+        className="block bg-white dark:bg-lounge-900/80 rounded-xl overflow-hidden border border-lounge-200/60 dark:border-lounge-800/50 hover:border-primary-300/50 dark:hover:border-primary-600/40 transition-all duration-500 hover:shadow-[0_12px_40px_rgba(201,165,94,0.12)] dark:hover:shadow-[0_12px_40px_rgba(201,165,94,0.08)]"
+      >
+        <div className={`aspect-[4/3] relative overflow-hidden bg-gradient-to-br ${gradient}`}>
+          {showImage ? (
+            <Image
+              src={imageUrl as string}
+              alt={`${name} logo`}
+              fill
+              className="object-contain p-6 bg-white/95 dark:bg-lounge-950/40 group-hover:scale-105 transition-transform duration-700 ease-out"
+              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+              onError={() => setImageError(true)}
+              unoptimized
+            />
+          ) : (
+            <>
+              <div className="absolute inset-0 opacity-30 mix-blend-overlay" style={{
+                backgroundImage:
+                  'radial-gradient(circle at 20% 20%, rgba(255,255,255,0.5), transparent 50%), radial-gradient(circle at 80% 80%, rgba(0,0,0,0.3), transparent 50%)',
+              }} />
+              <div className="relative h-full flex flex-col items-center justify-center px-4 text-center">
+                <span
+                  className="text-5xl sm:text-6xl font-normal text-white/95 tracking-tight leading-none mb-3 drop-shadow-sm"
+                  style={{ fontFamily: 'var(--font-display), serif' }}
+                >
+                  {initials}
+                </span>
+                <span className="text-[10px] uppercase tracking-[0.22em] text-white/70 font-semibold">
+                  Shisha Brand
+                </span>
+              </div>
+            </>
+          )}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+        </div>
+
+        <div className="p-4 sm:p-5">
+          <h3
+            className="text-base sm:text-lg text-lounge-900 dark:text-lounge-100 mb-1 line-clamp-1 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors"
+            style={{ fontFamily: 'var(--font-display), serif' }}
+          >
+            {name}
+          </h3>
+          <p className="text-[11px] uppercase tracking-[0.14em] font-semibold text-primary-600/80 dark:text-primary-400/80 mb-2">
+            {count} flavor{count === 1 ? '' : 's'}
+          </p>
+          {sampleFlavors.length > 0 && (
+            <p className="text-xs text-lounge-400 dark:text-lounge-500 line-clamp-2 leading-relaxed">
+              {sampleFlavors.slice(0, 2).join(' · ')}
+            </p>
+          )}
+        </div>
+      </Link>
+    </motion.div>
+  )
+}

--- a/data/brandImages.ts
+++ b/data/brandImages.ts
@@ -1,0 +1,16 @@
+import { normalizeBrandForSearch } from '../lib/utils/brandNormalizer'
+
+/**
+ * ブランド名 (normalizeBrandForSearch を通した小文字キー) → 画像URL のマップ。
+ * 画像は Wikimedia Commons などの信頼できる公開ホストを優先。
+ * 追加する場合は next.config.ts の remotePatterns に hostname を追加すること。
+ */
+const BRAND_IMAGE_ENTRIES: Record<string, string> = {
+  shiazo: 'https://upload.wikimedia.org/wikipedia/commons/c/ce/Shiazo_Blueberry.png',
+}
+
+export function getBrandImageUrl(brand: string): string | undefined {
+  return BRAND_IMAGE_ENTRIES[normalizeBrandForSearch(brand)]
+}
+
+export const REGISTERED_BRAND_IMAGE_COUNT = Object.keys(BRAND_IMAGE_ENTRIES).length

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'blogger.googleusercontent.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'upload.wikimedia.org',
+      },
     ],
   },
 }


### PR DESCRIPTION
## Summary
- `/brands` に全 98 シーシャブランドを一覧表示するディレクトリページを追加。人気順 / A–Z ソート、ブランド名検索、ブランドごとのフレーバー数とサンプル名表示付き
- ブランドロゴ画像は `data/brandImages.ts` (normalizeBrandForSearch キー) で URL マップ管理し、未登録のブランドはブランド名ハッシュから決まるゴールド系グラデーション + イニシャル表示のタイポグラフィカードにフォールバック。Shiazo を暫定登録 (Wikimedia Commons)
- ブランドカードから `/?manufacturer=...` に deep-link して既存検索にそのまま繋がる導線。ホームのヘッダー直下に「ブランド一覧を見る」リンクを追加
- `next.config.ts` の `images.remotePatterns` に `upload.wikimedia.org` を追加

## 実装メモ
- 98 ブランドぶんの公式ロゴを一括で収集するのは現実的でなかったため、まずはテキスト主体の統一デザインを土台にし、ブランド画像は追記しやすい形 (`data/brandImages.ts`) に切り出している。今後は主要ブランドから `BRAND_IMAGE_ENTRIES` に URL を追加していけば自動で画像表示に切り替わる
- 画像にはクライアント側 `onError` ハンドラを入れ、ロード失敗時はそのままフォールバックに戻るようにしてある
- `BrandSummary` 型は `/api/brands` と `/brands` の両方から再利用
- サーバーコンポーネント (`app/brands/page.tsx`) は `shishaData` から直接集計し、初期表示で API を叩かない

## Test plan
- [ ] `pnpm lint` ✅ (ローカルで通過)
- [ ] `pnpm test` ✅ (9 件全パス)
- [ ] `npx tsc --noEmit` ✅ (エラーなし)
- [ ] `pnpm dev` で `/brands` を開きブランドカードが並ぶこと
- [ ] 検索バーにブランド名を入れるとフィルタされること
- [ ] 人気順 / A–Z トグルでソートが切り替わること
- [ ] カードをクリックすると `/?manufacturer=...` に遷移し該当ブランドのフレーバーが出ること
- [ ] Shiazo カードに Wikimedia の画像が表示されること (画像取得失敗時はタイポグラフィカードに戻ること)

🤖 Generated with [Claude Code](https://claude.com/claude-code)