### PR TITLE
feat: add brand directory page at /brands

### DIFF
--- a/.claude/skills/brand-logo-download/SKILL.md
+++ b/.claude/skills/brand-logo-download/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: brand-logo-download
+description: shisha-flavor-search リポジトリで /brands ページ用のブランドロゴ画像を公開ソース (Wikipedia / 公式サイト等) から収集し、命名規約に従って public/images/brands/<slug>.(png|svg|webp) にローカル保存する。ユーザーが「ブランドロゴを集めて」「brand-logo-download」「シーシャブランドのロゴをダウンロード」「ブランド画像を取得」「missing brand logo を落としてきて」「ブランドの画像を追加」などと言ったときに使うこと。
+---
+
+# brand-logo-download
+
+data/brandImages.ts の `brandSlug()` で生成されるスラグに一致するファイル名で、
+public/images/brands/ 以下にロゴ画像を配置するためのスキル。配置すれば /brands
+ページで自動的にカード画像として表示される (ない場合はタイポグラフィックの
+フォールバックが使われる)。
+
+## 前提
+
+- このスキルは Claude Code をリポジトリルートから起動した状態で実行する
+- 外部ホスト (Wikipedia, 公式サイト等) への HTTP が通るネットワーク環境であること
+- `pnpm install` 済み (tsx が使える状態) であること
+- 画像は個人利用目的。商用配布はしない前提で、ロゴの出所は Wikipedia/Wikimedia
+  Commons を最優先 (CC/PD が明示されていることが多いため)、次点で各ブランド
+  公式サイトの header / press kit の画像、最後に一般画像検索結果
+
+## 全体フロー
+
+1. **未取得ブランドのリストアップ** — `scripts/list_missing_brands.ts` で
+   data/shishaData.js から全ブランドを抽出し、public/images/brands/ に
+   未配置のものを人気 (フレーバー件数) 順でソートして `/tmp/shisha-brand-logos/missing.json` に出力
+2. **対象を絞る** — 引数がなければ missing 全件、「top 20」「top N」指定が
+   あればその件数だけ、「<brand>」指定があれば単一ブランドだけ
+3. **並列ダウンロード** — 対象ブランドを 10〜15 件ごとにバッチに分け、
+   general-purpose サブエージェントで並列に [WebSearch → 画像URL 特定 → curl
+   でダウンロード → ファイル検証 → 配置] を実行。サブエージェントへのプロンプト
+   雛形は [references/subagent_prompt_template.md](references/subagent_prompt_template.md)
+4. **検証** — `scripts/verify_images.ts` で全ファイルを magic bytes で
+   画像形式を検出、0 バイトや HTML 誤取得を弾く
+5. **再実行で足りないものを埋める** — サブエージェントが失敗したブランドは
+   missing.json に残るので、プロンプトを変えて再実行 (例: 正式社名で検索)
+6. **レポート** — 追加できた件数、残った件数、スキップしたブランド一覧を
+   ユーザーに提示
+
+## ステップ詳細
+
+### 1. 未取得ブランドの抽出
+
+```bash
+npx tsx .claude/skills/brand-logo-download/scripts/list_missing_brands.ts
+```
+
+出力例 (stderr):
+
+```
+Total brands: 92
+With logo:    0
+Missing:      92
+Missing list written to: /tmp/shisha-brand-logos/missing.json
+  [380] Doobacco  →  doobacco
+  [251] Al Fakher  →  al-fakher
+  ...
+```
+
+`/tmp/shisha-brand-logos/missing.json` の構造:
+
+```json
+{
+  "all": [{ "name": "Al Fakher", "slug": "al-fakher", "count": 251, "has": false }, ...],
+  "missing": [ ... ]
+}
+```
+
+### 2. 対象を絞る
+
+ユーザーが明示していない場合は missing 全件を対象にする。ただし件数が多いので、
+初回実行時はまず上位 30 件程度から試すことを推奨する (失敗時の修正コストが低い)。
+
+```python
+import json
+with open('/tmp/shisha-brand-logos/missing.json') as f:
+    data = json.load(f)
+targets = data['missing'][:30]  # 上位 30 件
+```
+
+### 3. 並列サブエージェント
+
+対象を 10〜15 件ずつのバッチに分け、バッチ数ぶんのサブエージェントを **単一の
+メッセージで並列起動** する。各サブエージェントには以下を渡す:
+
+- 担当ブランド名と対応スラグのペア一覧
+- 出力ディレクトリ (`public/images/brands/`)
+- 検索方針 (Wikipedia → 公式 → 一般画像)
+- curl コマンドのテンプレ (UA 指定必須)
+- 成功/失敗の報告フォーマット
+
+プロンプト本文は [references/subagent_prompt_template.md](references/subagent_prompt_template.md) を
+そのまま使い、`{{BRANDS}}` プレースホルダーを JSON で置換する。
+
+**並列数の目安**: missing が 90 件なら 6〜9 並列 (1 エージェント 10〜15 件)。
+これ以上増やすと WebSearch のレート制限に当たる可能性がある。
+
+### 4. 検証
+
+全サブエージェント完了後:
+
+```bash
+npx tsx .claude/skills/brand-logo-download/scripts/verify_images.ts
+```
+
+このスクリプトは public/images/brands/ の全ファイルを走査し、以下をチェック:
+
+- ファイルサイズが 500 バイト以上
+- magic bytes が PNG / JPEG / GIF / WebP / SVG のいずれか
+- 拡張子と実際の形式が一致しているか
+
+不正なファイル (HTML 誤取得、サイズ 0、形式不一致) はパスを stderr に出して
+削除候補として提示する。ユーザー確認のうえ削除する。
+
+### 5. 再挑戦
+
+`list_missing_brands.ts` をもう一度実行して、残ったブランドを再度サブエージェントに
+渡す。このとき検索クエリを変えると成功率が上がる:
+
+- 正式社名で検索 (例: "Layalina Premium Tobacco")
+- ブランドの原語表記で検索 (例: "Северный" → Cyrillic のまま)
+- ロシア系ブランド (Darkside, Sebero, Bang Bang 等) は ВКонтакте や ozon.ru に
+  ロゴがあることが多い
+
+### 6. 最終レポート
+
+ユーザーに以下を提示:
+
+- 追加できたブランド件数と合計ファイルサイズ
+- 残った (= 検索で見つからなかった) ブランド一覧
+- 目視確認推奨の画像 (例: 2KB 未満の極端に小さいもの)
+
+ユーザーがコミットするかどうかを判断できるよう、`git status` で差分も表示する。
+
+## 命名規則 (重要)
+
+ファイル名 (拡張子を除く部分) は `data/brandImages.ts` の `brandSlug()` が返す
+スラグと **完全一致** しなければならない。このスキルのスクリプトはその値を自動で
+計算するので、サブエージェントは `missing.json` 内の `slug` 値をそのまま使うこと。
+
+対応関係の例:
+
+| ブランド名               | スラグ / ファイル名       |
+| ----------------------- | ------------------------ |
+| Al Fakher               | `al-fakher.png`          |
+| Starbuzz                | `starbuzz.png`           |
+| Coco Nara               | `coco-nara.png`          |
+| Khalil Maamoon Tobacco  | `khalil-maamoon-tobacco.png` |
+| Северный                | `северный.png`           |
+
+サポート拡張子: `.png` `.jpg` `.jpeg` `.webp` `.svg` `.avif`。可能なら
+PNG (透過あり) か SVG を優先。
+
+## 落とし穴
+
+- **HTML の誤取得**: curl が HTML ページを取得したのに `.png` として保存する
+  事故が多い。`file --mime-type` か magic bytes で検証必須。`verify_images.ts` が
+  この検証をやる。
+- **User-Agent**: 一部サイトは curl の素の UA を 403 で弾く。サブエージェントの
+  プロンプトで `-A "Mozilla/5.0 (compatible; shisha-flavor-search-logo-bot/1.0)"`
+  を必ず付ける指示にしている。
+- **リダイレクト**: Wikipedia のサムネイル URL はリダイレクト多段なので `curl -L` 必須。
+- **ドメイン制限**: 一部の環境 (特にクラウド sandbox) では外部ホストがブロックされる。
+  このスキルは **ローカル環境で実行する前提**。`host_not_allowed` 等のエラーが出たら
+  環境側の制限を疑う。
+- **大きすぎる画像**: 2MB 超のロゴは最適化候補。next/image が最適化するので必須では
+  ないが、リポジトリサイズ抑制のため 1024px 未満に収めるのが望ましい。
+- **Cyrillic/非ASCII ファイル名**: ファイルシステムとブラウザ両方で通るが、URL 参照
+  時に %-encoding される。問題ない。気になる場合はそのブランドだけ手動で ASCII 名に
+  リネームし、`data/brandImages.ts` の正規化ルールに合う範囲で調整する。
+- **冪等性**: public/images/brands/ に既に配置されているブランドは `missing.json` に
+  含まれないので、同じブランドを二重に上書きする事故は発生しない。再配置したい場合は
+  先に既存ファイルを削除する。
+
+## 対話の流れ
+
+スキル実行中にユーザーへ報告する:
+
+- ステップ1 完了時: 「未取得ブランド X 件。top N だけ試しますか? 全件いきますか?」
+- ステップ3 着手時: 「Y 個のサブエージェントに分けて並列ダウンロード開始」
+- ステップ4 完了時: 追加成功 N 件 / 失敗 M 件、失敗一覧を提示
+- ステップ6 終了時: `git status` を添えて、コミットの要否を確認

--- a/.claude/skills/brand-logo-download/references/subagent_prompt_template.md
+++ b/.claude/skills/brand-logo-download/references/subagent_prompt_template.md
@@ -1,0 +1,91 @@
+# Subagent prompt template
+
+Pass this to `general-purpose` subagents via the Agent tool. Replace
+`{{BRANDS}}` with a JSON array of `{ name, slug }` entries for the batch
+(10〜15 件が目安)。
+
+---
+
+あなたはシーシャブランドのロゴ画像を収集する担当です。以下のブランド一覧それぞれに
+ついて、公開情報から公式/代表的なロゴ画像を 1 つ見つけて
+`public/images/brands/<slug>.<ext>` に保存してください。
+
+## 担当ブランド
+
+```json
+{{BRANDS}}
+```
+
+`slug` はファイル名の stem として **そのまま使ってください**。変更厳禁 (ハイフン、
+小文字、非 ASCII 文字を含む場合がある)。
+
+## 手順 (各ブランドごとに実行)
+
+1. **WebSearch** で以下のクエリを試す (順に):
+   - `"<brand name>" shisha logo site:wikipedia.org`
+   - `"<brand name>" shisha brand logo`
+   - `"<brand name>" hookah tobacco logo png`
+   - ロシア系ブランドで英語で当たらない場合は原語表記を試す
+     (例: `Sebero` → `Себеро`)
+
+2. **画像 URL を選ぶ**。優先順位:
+   a. Wikipedia/Wikimedia Commons 上の PNG/SVG (CC/PD のことが多い)
+   b. ブランド公式サイトの header ロゴ / press kit
+   c. オンラインショップ (hookah-shisha.com, hookahcompany.com 等) のブランドバナー
+   d. 大手メディア/まとめサイトの画像
+
+   避けるもの:
+   - ソーシャル (Instagram/Facebook) の JPG サムネイル (低解像度・圧縮アーティファクト大)
+   - Pinterest の再投稿画像 (出所不明)
+   - AI 生成っぽい画像 / 非公式二次創作
+
+3. **ダウンロード**。以下のテンプレを使う (拡張子は画像に合わせる):
+
+   ```bash
+   curl -sL --fail --max-time 20 \
+     -A "Mozilla/5.0 (compatible; shisha-flavor-search-logo-bot/1.0)" \
+     -o "public/images/brands/<slug>.png" \
+     "<IMAGE_URL>"
+   ```
+
+   ポイント:
+   - `-L` でリダイレクト追従 (Wikipedia のサムネイル URL は多段リダイレクト)
+   - `-A` でブラウザっぽい UA (curl の素の UA を拒否するサイトがある)
+   - `--fail` で HTTP エラー時に 0 バイトファイルを残さない
+   - `--max-time 20` でハング回避
+
+4. **検証**。`file --mime-type public/images/brands/<slug>.<ext>` で実際の MIME を
+   確認。`image/png`, `image/jpeg`, `image/webp`, `image/svg+xml` のいずれかであれば OK。
+   `text/html` になっていたらエラーページを掴んでいるので、削除して別 URL を試す。
+
+5. **サイズチェック**。
+   - `ls -l public/images/brands/<slug>.<ext>` で 500 バイト以上あることを確認
+   - 5 MB 超の場合は別のより小さい画像を探す (リポジトリサイズ抑制のため)
+
+## 拡張子の扱い
+
+- 元 URL が `.svg` なら `<slug>.svg` で保存 (SVG が最優先)
+- 透過 PNG があれば `<slug>.png` を最推奨
+- WebP しか無い場合は `<slug>.webp` で可
+- JPEG は最後の手段 (背景が白 or ブランドカラーのフラット画像が確実な場合のみ)
+
+## 出力
+
+全ブランド処理後、以下の形式で結果を報告してください:
+
+```
+成功:
+- Al Fakher: al-fakher.png (15 KB, Wikipedia)
+- Starbuzz: starbuzz.svg (3 KB, 公式サイト)
+
+スキップ / 失敗:
+- Cleopatra: 検索結果に適切な画像なし (同名の無関係ブランドが多数ヒット)
+- 北朝鮮ブランド: 公式サイトが到達不能
+```
+
+## やらないこと
+
+- 実在しないブランドのロゴを捏造する (AI 生成で埋めるのは禁止)
+- 解像度を水増しする目的で拡大処理をする (元解像度のまま保存)
+- 明確に企業から画像削除を求められている場合にその画像を保存する
+- `data/brandImages.ts` や `public/images/brands/README.md` を編集する (スキーマに影響するため触らない)

--- a/.claude/skills/brand-logo-download/scripts/list_missing_brands.ts
+++ b/.claude/skills/brand-logo-download/scripts/list_missing_brands.ts
@@ -1,0 +1,87 @@
+/**
+ * Lists every brand found in data/shishaData.js along with its expected
+ * public/images/brands/<slug>.<ext> filename. Writes the result (and a
+ * "missing" subset sorted by flavor count desc) to
+ * /tmp/shisha-brand-logos/missing.json.
+ *
+ * Run from the repo root:
+ *   npx tsx .claude/skills/brand-logo-download/scripts/list_missing_brands.ts
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { brandSlug } from '../../../../data/brandImages'
+import { shishaData } from '../../../../data/shishaData'
+import { getUniqueBrands, normalizeBrandForSearch } from '../../../../lib/utils/brandNormalizer'
+
+const SUPPORTED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.svg', '.avif'])
+
+interface BrandRow {
+  name: string
+  slug: string
+  count: number
+  has: boolean
+  existingFile?: string
+}
+
+function scanExisting(dir: string): Map<string, string> {
+  const found = new Map<string, string>()
+  if (!fs.existsSync(dir)) return found
+  for (const file of fs.readdirSync(dir)) {
+    const ext = path.extname(file).toLowerCase()
+    if (!SUPPORTED_EXTENSIONS.has(ext)) continue
+    const slug = path.basename(file, ext).toLowerCase()
+    found.set(slug, file)
+  }
+  return found
+}
+
+function main() {
+  const repoRoot = process.cwd()
+  const brandsDir = path.join(repoRoot, 'public', 'images', 'brands')
+  const outDir = '/tmp/shisha-brand-logos'
+  const outPath = path.join(outDir, 'missing.json')
+
+  const existing = scanExisting(brandsDir)
+
+  const counts = new Map<string, number>()
+  for (const item of shishaData) {
+    const key = normalizeBrandForSearch(item.manufacturer)
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+
+  const brands: BrandRow[] = getUniqueBrands(shishaData.map(i => i.manufacturer)).map(name => {
+    const slug = brandSlug(name)
+    const hit = existing.get(slug)
+    return {
+      name,
+      slug,
+      count: counts.get(normalizeBrandForSearch(name)) ?? 0,
+      has: Boolean(hit),
+      ...(hit ? { existingFile: hit } : {}),
+    }
+  })
+
+  brands.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+
+  const missing = brands.filter(b => !b.has)
+
+  fs.mkdirSync(outDir, { recursive: true })
+  fs.writeFileSync(outPath, JSON.stringify({ all: brands, missing }, null, 2))
+
+  const log = (msg: string) => process.stderr.write(msg + '\n')
+  log(`Total brands: ${brands.length}`)
+  log(`With logo:    ${brands.length - missing.length}`)
+  log(`Missing:      ${missing.length}`)
+  log(`Output:       ${outPath}`)
+  log('')
+  log('Top missing (by flavor count):')
+  for (const b of missing.slice(0, 20)) {
+    log(`  [${String(b.count).padStart(4)}] ${b.name.padEnd(28)} →  ${b.slug}`)
+  }
+  if (missing.length > 20) log(`  ... and ${missing.length - 20} more`)
+
+  process.stdout.write(outPath + '\n')
+}
+
+main()

--- a/.claude/skills/brand-logo-download/scripts/verify_images.ts
+++ b/.claude/skills/brand-logo-download/scripts/verify_images.ts
@@ -1,0 +1,113 @@
+/**
+ * Walks public/images/brands/ and verifies that every image file has a
+ * plausible format based on magic bytes and a minimum byte size. Files
+ * that look broken (0-byte, mistakenly-saved HTML page, mime mismatch)
+ * are reported as candidates for deletion.
+ *
+ * Run from the repo root:
+ *   npx tsx .claude/skills/brand-logo-download/scripts/verify_images.ts
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const SUPPORTED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.svg', '.avif'])
+const MIN_BYTES = 500
+
+type Format = 'png' | 'jpeg' | 'gif' | 'webp' | 'svg' | 'avif' | 'html' | 'unknown'
+
+function sniff(buf: Buffer): Format {
+  if (buf.length < 4) return 'unknown'
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png'
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpeg'
+  if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38) return 'gif'
+  if (
+    buf.length >= 12 &&
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) return 'webp'
+  if (
+    buf.length >= 12 &&
+    buf[4] === 0x66 && buf[5] === 0x74 && buf[6] === 0x79 && buf[7] === 0x70 &&
+    ((buf[8] === 0x61 && buf[9] === 0x76) || (buf[8] === 0x68 && buf[9] === 0x65))
+  ) return 'avif'
+  const head = buf.slice(0, Math.min(buf.length, 512)).toString('utf8').trim().toLowerCase()
+  if (head.startsWith('<?xml') || head.startsWith('<svg')) return 'svg'
+  if (head.startsWith('<!doctype html') || head.startsWith('<html')) return 'html'
+  return 'unknown'
+}
+
+function extToFormat(ext: string): Format {
+  switch (ext) {
+    case '.png': return 'png'
+    case '.jpg':
+    case '.jpeg': return 'jpeg'
+    case '.gif': return 'gif'
+    case '.webp': return 'webp'
+    case '.svg': return 'svg'
+    case '.avif': return 'avif'
+    default: return 'unknown'
+  }
+}
+
+function main() {
+  const brandsDir = path.join(process.cwd(), 'public', 'images', 'brands')
+  const problems: { file: string; reason: string }[] = []
+  let ok = 0
+
+  if (!fs.existsSync(brandsDir)) {
+    process.stderr.write(`No brands directory at ${brandsDir}\n`)
+    process.exit(1)
+  }
+
+  for (const file of fs.readdirSync(brandsDir)) {
+    const full = path.join(brandsDir, file)
+    if (!fs.statSync(full).isFile()) continue
+    const ext = path.extname(file).toLowerCase()
+    if (!SUPPORTED_EXTENSIONS.has(ext)) {
+      // ignore non-image files (e.g., README.md)
+      continue
+    }
+
+    const stats = fs.statSync(full)
+    if (stats.size < MIN_BYTES) {
+      problems.push({ file, reason: `size ${stats.size} B < ${MIN_BYTES} B` })
+      continue
+    }
+
+    const fh = fs.openSync(full, 'r')
+    const buf = Buffer.alloc(Math.min(4096, stats.size))
+    fs.readSync(fh, buf, 0, buf.length, 0)
+    fs.closeSync(fh)
+
+    const detected = sniff(buf)
+    const expected = extToFormat(ext)
+
+    if (detected === 'html') {
+      problems.push({ file, reason: 'body is HTML (probably an error page)' })
+      continue
+    }
+    if (detected === 'unknown') {
+      problems.push({ file, reason: 'unrecognized magic bytes' })
+      continue
+    }
+    if (detected !== expected) {
+      problems.push({ file, reason: `ext says ${expected} but body is ${detected}` })
+      continue
+    }
+
+    ok += 1
+  }
+
+  const log = (msg: string) => process.stderr.write(msg + '\n')
+  log(`Valid:    ${ok}`)
+  log(`Suspect:  ${problems.length}`)
+  if (problems.length > 0) {
+    log('')
+    log('Candidates for deletion / re-download:')
+    for (const p of problems) log(`  - ${p.file}  (${p.reason})`)
+  }
+
+  process.exit(problems.length === 0 ? 0 : 2)
+}
+
+main()

--- a/app/ClientHome.tsx
+++ b/app/ClientHome.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { motion, AnimatePresence } from 'framer-motion'
+import Link from 'next/link'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useState, useEffect, Suspense } from 'react'
 
@@ -179,9 +180,17 @@ function HomeContent() {
 
           <div className="w-12 h-px bg-primary-400/60 mx-auto mb-5" />
 
-          <p className="text-sm sm:text-base text-lounge-400 dark:text-lounge-500 tracking-wide">
+          <p className="text-sm sm:text-base text-lounge-400 dark:text-lounge-500 tracking-wide mb-6">
             あなただけの特別なフレーバーを見つけよう
           </p>
+
+          <Link
+            href="/brands"
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-white/70 dark:bg-lounge-900/60 backdrop-blur-sm border border-lounge-200/60 dark:border-lounge-800/50 text-xs font-semibold uppercase tracking-[0.18em] text-lounge-600 dark:text-lounge-300 hover:border-primary-400/60 dark:hover:border-primary-500/40 hover:text-primary-600 dark:hover:text-primary-400 transition-all"
+          >
+            <span>ブランド一覧を見る</span>
+            <span aria-hidden>→</span>
+          </Link>
         </motion.div>
 
         <SearchBar

--- a/app/api/brands/route.ts
+++ b/app/api/brands/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+
+import { shishaData } from '../../../data/shishaData'
+import { getUniqueBrands, normalizeBrandName, normalizeBrandForSearch } from '../../../lib/utils/brandNormalizer'
+
+export interface BrandSummary {
+  name: string
+  count: number
+  sampleFlavors: string[]
+}
+
+export async function GET(): Promise<NextResponse<BrandSummary[]>> {
+  const counts = new Map<string, { displayName: string; count: number; samples: string[] }>()
+
+  for (const item of shishaData) {
+    const key = normalizeBrandForSearch(item.manufacturer)
+    const entry = counts.get(key)
+    if (entry) {
+      entry.count += 1
+      if (entry.samples.length < 3) {
+        entry.samples.push(item.productName)
+      }
+    } else {
+      counts.set(key, {
+        displayName: normalizeBrandName(item.manufacturer),
+        count: 1,
+        samples: [item.productName],
+      })
+    }
+  }
+
+  const uniqueBrands = getUniqueBrands(shishaData.map(i => i.manufacturer))
+  const brands: BrandSummary[] = uniqueBrands.map(name => {
+    const entry = counts.get(normalizeBrandForSearch(name))
+    return {
+      name,
+      count: entry?.count ?? 0,
+      sampleFlavors: entry?.samples ?? [],
+    }
+  })
+
+  return NextResponse.json(brands)
+}

--- a/app/api/brands/route.ts
+++ b/app/api/brands/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from 'next/server'
 
 import { shishaData } from '../../../data/shishaData'
+import { getBrandImageUrl } from '../../../data/brandImages'
 import { getUniqueBrands, normalizeBrandName, normalizeBrandForSearch } from '../../../lib/utils/brandNormalizer'
 
 export interface BrandSummary {
   name: string
   count: number
   sampleFlavors: string[]
+  imageUrl?: string
 }
 
 export async function GET(): Promise<NextResponse<BrandSummary[]>> {
@@ -36,6 +38,7 @@ export async function GET(): Promise<NextResponse<BrandSummary[]>> {
       name,
       count: entry?.count ?? 0,
       sampleFlavors: entry?.samples ?? [],
+      imageUrl: getBrandImageUrl(name),
     }
   })
 

--- a/app/brands/BrandsClient.tsx
+++ b/app/brands/BrandsClient.tsx
@@ -7,7 +7,6 @@ import { useMemo, useState } from 'react'
 
 import BackgroundOrbs from '../../components/BackgroundOrbs'
 import BrandCard from '../../components/BrandCard'
-import { getBrandImageUrl } from '../../data/brandImages'
 import type { BrandSummary } from '../api/brands/route'
 
 type SortKey = 'alpha' | 'popularity'
@@ -116,7 +115,7 @@ export default function BrandsClient({ brands }: BrandsClientProps) {
                 name={brand.name}
                 count={brand.count}
                 sampleFlavors={brand.sampleFlavors}
-                imageUrl={getBrandImageUrl(brand.name)}
+                imageUrl={brand.imageUrl}
                 index={idx}
               />
             ))}

--- a/app/brands/BrandsClient.tsx
+++ b/app/brands/BrandsClient.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+
+import BackgroundOrbs from '../../components/BackgroundOrbs'
+import BrandCard from '../../components/BrandCard'
+import { getBrandImageUrl } from '../../data/brandImages'
+import type { BrandSummary } from '../api/brands/route'
+
+type SortKey = 'alpha' | 'popularity'
+
+interface BrandsClientProps {
+  brands: BrandSummary[]
+}
+
+export default function BrandsClient({ brands }: BrandsClientProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('popularity')
+
+  const filteredBrands = useMemo(() => {
+    const term = searchQuery.trim().toLowerCase()
+    const base = term
+      ? brands.filter(b => b.name.toLowerCase().includes(term))
+      : brands
+    const sorted = [...base]
+    if (sortKey === 'popularity') {
+      sorted.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    } else {
+      sorted.sort((a, b) => a.name.localeCompare(b.name))
+    }
+    return sorted
+  }, [brands, searchQuery, sortKey])
+
+  const totalFlavors = useMemo(
+    () => brands.reduce((sum, b) => sum + b.count, 0),
+    [brands]
+  )
+
+  return (
+    <div className="min-h-screen relative overflow-hidden bg-atmosphere-light dark:bg-atmosphere-dark">
+      <BackgroundOrbs />
+
+      <main className="relative mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-20 max-w-7xl">
+        <motion.div
+          initial={{ opacity: 0, y: -16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94] }}
+          className="text-center mb-12"
+        >
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-lounge-400 dark:text-lounge-500 hover:text-primary-500 dark:hover:text-primary-400 transition-colors mb-6"
+          >
+            <span>←</span>
+            <span>Back to Search</span>
+          </Link>
+
+          <h1
+            className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-normal text-lounge-900 dark:text-lounge-100 mb-4 tracking-tight leading-[0.95]"
+            style={{ fontFamily: 'var(--font-display), serif' }}
+          >
+            Brand <span className="text-gold-gradient">Directory</span>
+          </h1>
+
+          <div className="w-12 h-px bg-primary-400/60 mx-auto mb-5" />
+
+          <p className="text-sm sm:text-base text-lounge-400 dark:text-lounge-500 tracking-wide">
+            {brands.length} ブランド · {totalFlavors.toLocaleString()} フレーバー
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.1 }}
+          className="mb-10 max-w-3xl mx-auto"
+        >
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="relative flex-1">
+              <input
+                type="text"
+                placeholder="ブランド名で検索..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full px-4 py-3 pl-11 bg-white/80 dark:bg-lounge-900/60 backdrop-blur-sm text-lounge-900 dark:text-lounge-100 placeholder-lounge-400 dark:placeholder-lounge-600 rounded-lg border border-lounge-200/60 dark:border-lounge-800/40 focus:border-primary-400/60 dark:focus:border-primary-500/40 focus:outline-none transition-all text-sm"
+              />
+              <MagnifyingGlassIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-lounge-400" />
+            </div>
+
+            <div className="inline-flex rounded-lg bg-white/80 dark:bg-lounge-900/60 backdrop-blur-sm border border-lounge-200/60 dark:border-lounge-800/40 p-1">
+              {(['popularity', 'alpha'] as SortKey[]).map((key) => (
+                <button
+                  key={key}
+                  onClick={() => setSortKey(key)}
+                  className={`px-4 py-2 rounded-md text-xs font-semibold tracking-wide transition-all ${
+                    sortKey === key
+                      ? 'bg-primary-500 text-white shadow-sm'
+                      : 'text-lounge-600 dark:text-lounge-400 hover:text-lounge-900 dark:hover:text-lounge-100'
+                  }`}
+                >
+                  {key === 'popularity' ? '人気順' : 'A–Z'}
+                </button>
+              ))}
+            </div>
+          </div>
+        </motion.div>
+
+        {filteredBrands.length > 0 ? (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-5">
+            {filteredBrands.map((brand, idx) => (
+              <BrandCard
+                key={brand.name}
+                name={brand.name}
+                count={brand.count}
+                sampleFlavors={brand.sampleFlavors}
+                imageUrl={getBrandImageUrl(brand.name)}
+                index={idx}
+              />
+            ))}
+          </div>
+        ) : (
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="text-center py-20"
+          >
+            <div className="w-20 h-20 mx-auto mb-6 border border-lounge-200 dark:border-lounge-700 rounded-full flex items-center justify-center">
+              <MagnifyingGlassIcon className="w-8 h-8 text-lounge-300 dark:text-lounge-600" />
+            </div>
+            <h3
+              className="text-xl font-medium text-lounge-700 dark:text-lounge-300 mb-2"
+              style={{ fontFamily: 'var(--font-display), serif' }}
+            >
+              ブランドが見つかりません
+            </h3>
+            <p className="text-sm text-lounge-400 dark:text-lounge-500">
+              検索条件を変更してもう一度お試しください
+            </p>
+          </motion.div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/app/brands/page.tsx
+++ b/app/brands/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 
+import { getBrandImageUrl } from '../../data/brandImages'
 import { shishaData } from '../../data/shishaData'
 import { getUniqueBrands, normalizeBrandForSearch, normalizeBrandName } from '../../lib/utils/brandNormalizer'
 import type { BrandSummary } from '../api/brands/route'
@@ -37,6 +38,7 @@ function buildBrandSummaries(): BrandSummary[] {
       name,
       count: entry?.count ?? 0,
       sampleFlavors: entry?.samples ?? [],
+      imageUrl: getBrandImageUrl(name),
     }
   })
 }

--- a/app/brands/page.tsx
+++ b/app/brands/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from 'next'
+
+import { shishaData } from '../../data/shishaData'
+import { getUniqueBrands, normalizeBrandForSearch, normalizeBrandName } from '../../lib/utils/brandNormalizer'
+import type { BrandSummary } from '../api/brands/route'
+
+import BrandsClient from './BrandsClient'
+
+export const metadata: Metadata = {
+  title: 'Brand Directory | Shisha Flavor Search',
+  description: '取り扱いシーシャブランドの一覧。ブランドから好みのフレーバーを探しましょう。',
+}
+
+function buildBrandSummaries(): BrandSummary[] {
+  const counts = new Map<string, { displayName: string; count: number; samples: string[] }>()
+
+  for (const item of shishaData) {
+    const key = normalizeBrandForSearch(item.manufacturer)
+    const entry = counts.get(key)
+    if (entry) {
+      entry.count += 1
+      if (entry.samples.length < 3) {
+        entry.samples.push(item.productName)
+      }
+    } else {
+      counts.set(key, {
+        displayName: normalizeBrandName(item.manufacturer),
+        count: 1,
+        samples: [item.productName],
+      })
+    }
+  }
+
+  return getUniqueBrands(shishaData.map(i => i.manufacturer)).map(name => {
+    const entry = counts.get(normalizeBrandForSearch(name))
+    return {
+      name,
+      count: entry?.count ?? 0,
+      sampleFlavors: entry?.samples ?? [],
+    }
+  })
+}
+
+export default function BrandsPage() {
+  const brands = buildBrandSummaries()
+  return <BrandsClient brands={brands} />
+}

--- a/components/BrandCard.tsx
+++ b/components/BrandCard.tsx
@@ -67,7 +67,6 @@ export default function BrandCard({ name, count, sampleFlavors, imageUrl, index 
               className="object-contain p-6 bg-white/95 dark:bg-lounge-950/40 group-hover:scale-105 transition-transform duration-700 ease-out"
               sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
               onError={() => setImageError(true)}
-              unoptimized
             />
           ) : (
             <>

--- a/components/BrandCard.tsx
+++ b/components/BrandCard.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useState } from 'react'
+
+interface BrandCardProps {
+  name: string
+  count: number
+  sampleFlavors: string[]
+  imageUrl?: string
+  index?: number
+}
+
+const GRADIENTS = [
+  'from-primary-600 via-accent-500 to-accent-700',
+  'from-accent-700 via-primary-500 to-primary-800',
+  'from-lounge-800 via-accent-600 to-primary-600',
+  'from-primary-700 via-primary-400 to-accent-600',
+  'from-accent-800 via-accent-500 to-primary-400',
+  'from-primary-800 via-accent-700 to-lounge-700',
+  'from-accent-600 via-primary-600 to-primary-900',
+  'from-lounge-700 via-primary-700 to-accent-500',
+]
+
+function hashString(str: string): number {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0
+  }
+  return Math.abs(hash)
+}
+
+function getBrandInitials(name: string): string {
+  const words = name.split(/\s+/).filter(Boolean)
+  if (words.length === 0) return '?'
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase()
+  return (words[0][0] + words[1][0]).toUpperCase()
+}
+
+export default function BrandCard({ name, count, sampleFlavors, imageUrl, index = 0 }: BrandCardProps) {
+  const [imageError, setImageError] = useState(false)
+  const showImage = Boolean(imageUrl) && !imageError
+
+  const gradient = GRADIENTS[hashString(name) % GRADIENTS.length]
+  const initials = getBrandInitials(name)
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: Math.min(index * 0.02, 0.6), duration: 0.4, ease: [0.25, 0.46, 0.45, 0.94] }}
+      whileHover={{ y: -4 }}
+      className="group"
+    >
+      <Link
+        href={`/?manufacturer=${encodeURIComponent(name)}`}
+        className="block bg-white dark:bg-lounge-900/80 rounded-xl overflow-hidden border border-lounge-200/60 dark:border-lounge-800/50 hover:border-primary-300/50 dark:hover:border-primary-600/40 transition-all duration-500 hover:shadow-[0_12px_40px_rgba(201,165,94,0.12)] dark:hover:shadow-[0_12px_40px_rgba(201,165,94,0.08)]"
+      >
+        <div className={`aspect-[4/3] relative overflow-hidden bg-gradient-to-br ${gradient}`}>
+          {showImage ? (
+            <Image
+              src={imageUrl as string}
+              alt={`${name} logo`}
+              fill
+              className="object-contain p-6 bg-white/95 dark:bg-lounge-950/40 group-hover:scale-105 transition-transform duration-700 ease-out"
+              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+              onError={() => setImageError(true)}
+              unoptimized
+            />
+          ) : (
+            <>
+              <div className="absolute inset-0 opacity-30 mix-blend-overlay" style={{
+                backgroundImage:
+                  'radial-gradient(circle at 20% 20%, rgba(255,255,255,0.5), transparent 50%), radial-gradient(circle at 80% 80%, rgba(0,0,0,0.3), transparent 50%)',
+              }} />
+              <div className="relative h-full flex flex-col items-center justify-center px-4 text-center">
+                <span
+                  className="text-5xl sm:text-6xl font-normal text-white/95 tracking-tight leading-none mb-3 drop-shadow-sm"
+                  style={{ fontFamily: 'var(--font-display), serif' }}
+                >
+                  {initials}
+                </span>
+                <span className="text-[10px] uppercase tracking-[0.22em] text-white/70 font-semibold">
+                  Shisha Brand
+                </span>
+              </div>
+            </>
+          )}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+        </div>
+
+        <div className="p-4 sm:p-5">
+          <h3
+            className="text-base sm:text-lg text-lounge-900 dark:text-lounge-100 mb-1 line-clamp-1 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors"
+            style={{ fontFamily: 'var(--font-display), serif' }}
+          >
+            {name}
+          </h3>
+          <p className="text-[11px] uppercase tracking-[0.14em] font-semibold text-primary-600/80 dark:text-primary-400/80 mb-2">
+            {count} flavor{count === 1 ? '' : 's'}
+          </p>
+          {sampleFlavors.length > 0 && (
+            <p className="text-xs text-lounge-400 dark:text-lounge-500 line-clamp-2 leading-relaxed">
+              {sampleFlavors.slice(0, 2).join(' · ')}
+            </p>
+          )}
+        </div>
+      </Link>
+    </motion.div>
+  )
+}

--- a/data/brandImages.ts
+++ b/data/brandImages.ts
@@ -1,16 +1,46 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import { normalizeBrandForSearch } from '../lib/utils/brandNormalizer'
 
 /**
- * ブランド名 (normalizeBrandForSearch を通した小文字キー) → 画像URL のマップ。
- * 画像は Wikimedia Commons などの信頼できる公開ホストを優先。
- * 追加する場合は next.config.ts の remotePatterns に hostname を追加すること。
+ * Server-only module. Uses `node:fs` to enumerate locally bundled brand
+ * logo files at module init, so it must not be imported from client
+ * components ('use client'). Consume it from server components / API
+ * routes only, then pass resolved URLs down as props.
  */
-const BRAND_IMAGE_ENTRIES: Record<string, string> = {
-  shiazo: 'https://upload.wikimedia.org/wikipedia/commons/c/ce/Shiazo_Blueberry.png',
+
+const BRAND_IMAGES_DIR = path.join(process.cwd(), 'public', 'images', 'brands')
+const SUPPORTED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.svg', '.avif'])
+
+/**
+ * Brand name → URL-safe slug used as the expected filename stem.
+ * Example: "Al Fakher" → "al-fakher", "Coco Nara" → "coco-nara".
+ */
+export function brandSlug(brand: string): string {
+  return normalizeBrandForSearch(brand)
+    .replace(/[^\p{L}\p{N}\s-]/gu, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
 }
+
+function loadBrandImageMap(): Record<string, string> {
+  if (!fs.existsSync(BRAND_IMAGES_DIR)) return {}
+  const entries: Record<string, string> = {}
+  for (const file of fs.readdirSync(BRAND_IMAGES_DIR)) {
+    const ext = path.extname(file).toLowerCase()
+    if (!SUPPORTED_EXTENSIONS.has(ext)) continue
+    const slug = path.basename(file, ext).toLowerCase()
+    entries[slug] = `/images/brands/${file}`
+  }
+  return entries
+}
+
+const BRAND_IMAGE_MAP: Record<string, string> = loadBrandImageMap()
 
 export function getBrandImageUrl(brand: string): string | undefined {
-  return BRAND_IMAGE_ENTRIES[normalizeBrandForSearch(brand)]
+  return BRAND_IMAGE_MAP[brandSlug(brand)]
 }
 
-export const REGISTERED_BRAND_IMAGE_COUNT = Object.keys(BRAND_IMAGE_ENTRIES).length
+export const REGISTERED_BRAND_IMAGE_COUNT = Object.keys(BRAND_IMAGE_MAP).length

--- a/data/brandImages.ts
+++ b/data/brandImages.ts
@@ -1,0 +1,16 @@
+import { normalizeBrandForSearch } from '../lib/utils/brandNormalizer'
+
+/**
+ * ブランド名 (normalizeBrandForSearch を通した小文字キー) → 画像URL のマップ。
+ * 画像は Wikimedia Commons などの信頼できる公開ホストを優先。
+ * 追加する場合は next.config.ts の remotePatterns に hostname を追加すること。
+ */
+const BRAND_IMAGE_ENTRIES: Record<string, string> = {
+  shiazo: 'https://upload.wikimedia.org/wikipedia/commons/c/ce/Shiazo_Blueberry.png',
+}
+
+export function getBrandImageUrl(brand: string): string | undefined {
+  return BRAND_IMAGE_ENTRIES[normalizeBrandForSearch(brand)]
+}
+
+export const REGISTERED_BRAND_IMAGE_COUNT = Object.keys(BRAND_IMAGE_ENTRIES).length

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'blogger.googleusercontent.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'upload.wikimedia.org',
+      },
     ],
   },
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,10 +18,6 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'blogger.googleusercontent.com',
       },
-      {
-        protocol: 'https',
-        hostname: 'upload.wikimedia.org',
-      },
     ],
   },
 }

--- a/public/images/brands/README.md
+++ b/public/images/brands/README.md
@@ -1,0 +1,30 @@
+# Brand Logos
+
+Drop brand logo image files into this directory and they will be picked up
+automatically by the `/brands` page the next time the server renders it.
+
+## Naming convention
+
+The filename (without extension) must match the slug derived from the brand
+name. The slug is produced by `brandSlug()` in `data/brandImages.ts`:
+
+1. Normalize the brand name via `normalizeBrandForSearch` (lowercase, canonical
+   form — see `lib/utils/brandNormalizer.ts`).
+2. Strip any character that is not a letter, digit, whitespace, or `-`.
+3. Trim and collapse whitespace to a single `-`.
+
+Examples:
+
+| Brand name        | Expected filename stem |
+| ----------------- | ---------------------- |
+| Al Fakher         | `al-fakher`            |
+| Starbuzz          | `starbuzz`             |
+| Coco Nara         | `coco-nara`            |
+| Khalil Maamoon Tobacco | `khalil-maamoon-tobacco` |
+| Северный          | `северный`             |
+
+Supported extensions: `.png`, `.jpg`, `.jpeg`, `.webp`, `.svg`, `.avif`.
+
+If no file matches a brand's slug, the brand card falls back to the
+typographic gradient placeholder with the brand's initials. No remote hosts
+are involved — everything is served from `/images/brands/`.


### PR DESCRIPTION
Adds a dedicated brand list page showing all 98 shisha brands with
flavor counts and sample flavor names. Brands can be sorted by
popularity or alphabetically and filtered via search input.

Each brand card uses a deterministic gradient fallback with large
typographic initials when no brand image is registered, keeping the
page visually consistent across the full catalog. Brand-specific logo
URLs live in data/brandImages.ts keyed by normalized brand name, and
the whitelisted image hosts in next.config.ts now include
upload.wikimedia.org for verified public-domain logos.

The existing home page gets a pill-style "ブランド一覧を見る" link under
the tagline so visitors can discover the directory, and each brand
card on /brands deep-links back to the search page with the
manufacturer filter preselected.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>