### PR TITLE
fix(masthead): link brands-page title to home and match home's casing

### DIFF
--- a/app/ClientHome.tsx
+++ b/app/ClientHome.tsx
@@ -160,7 +160,7 @@ function HomeContent() {
             <button
               type="button"
               onClick={handleHomeReset}
-              className="font-sans-tight font-semibold text-sm tracking-[-0.01em] text-ink-950 dark:text-ink-50 hover:text-ember-500 transition-colors"
+              className="font-sans-tight font-semibold text-sm normal-case tracking-[-0.01em] text-ink-950 dark:text-ink-50 hover:text-ember-500 transition-colors"
             >
               Shisha Flavor Ledger
             </button>

--- a/app/brands/BrandsClient.tsx
+++ b/app/brands/BrandsClient.tsx
@@ -43,9 +43,12 @@ export default function BrandsClient({ brands }: BrandsClientProps) {
         <header className="flex flex-wrap items-center justify-between gap-3 py-3 border-t-2 border-b border-ink-900 dark:border-ink-100 font-mono-tight text-[10px] uppercase tracking-[0.16em] text-ink-700 dark:text-ink-200 mb-0">
           <span className="flex items-center gap-3">
             <span className="inline-block w-2 h-2 bg-ember-500" aria-hidden />
-            <span className="font-sans-tight font-semibold text-sm tracking-[-0.01em] text-ink-950 dark:text-ink-50">
+            <Link
+              href="/"
+              className="font-sans-tight font-semibold text-sm normal-case tracking-[-0.01em] text-ink-950 dark:text-ink-50 hover:text-ember-500 transition-colors"
+            >
               Shisha Flavor Ledger
-            </span>
+            </Link>
             <span className="hidden sm:inline text-ink-400 dark:text-ink-500">—</span>
             <span className="hidden sm:inline nums">Vol.&nbsp;I · Ed.&nbsp;2026</span>
           </span>


### PR DESCRIPTION
The /brands masthead rendered the wordmark inside a <span>, which inherited the header's uppercase transform, while / rendered it inside a <button> whose UA default text-transform:none silently cancelled the uppercase. Result: the same text showed as "SHISHA FLAVOR LEDGER" vs "Shisha Flavor Ledger" depending on the page, and the brands-page title wasn't clickable.

Switch the brands title to a <Link href="/"> and pin both sites with an explicit normal-case class so browser quirks can't diverge again.