### PR TITLE
perf: revert /flavor/[id] to dynamic SSR to shrink deploy

### DIFF
--- a/app/flavor/[id]/page.tsx
+++ b/app/flavor/[id]/page.tsx
@@ -16,12 +16,6 @@ function findFlavor(id: string): ShishaFlavor | null {
   return (shishaData as ShishaFlavor[]).find((f) => f.id === parsed) ?? null
 }
 
-export async function generateStaticParams(): Promise<{ id: string }[]> {
-  return (shishaData as ShishaFlavor[]).map((f) => ({ id: String(f.id) }))
-}
-
-export const dynamicParams = false
-
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { id } = await params
   const flavor = findFlavor(id)


### PR DESCRIPTION
Prerendering all ~5.3k flavor pages ballooned deploys to ~5 minutes. /brands/[slug] stays SSG (only 92 pages, negligible build cost) but flavor pages go back to server-rendered on demand. The page is still a Server Component reading shishaData directly, so the lookup is a microsecond array scan — the user-facing TTFB delta is negligible and everything past the first hit is CDN-cached.