### PR TITLE
一覧カードの country 表示を国旗アイコン化 (hover で日本語国名)

### DIFF
--- a/components/CountryFlag.tsx
+++ b/components/CountryFlag.tsx
@@ -1,0 +1,32 @@
+import { getCountryDisplay } from '../lib/utils/countryDisplay'
+
+interface CountryFlagProps {
+  country?: string | null
+  className?: string
+}
+
+export default function CountryFlag({ country, className = '' }: CountryFlagProps) {
+  const display = getCountryDisplay(country)
+  if (!display) return null
+
+  return (
+    <span
+      className={`relative inline-flex items-center group/flag ${className}`}
+      title={display.label}
+    >
+      <span
+        aria-hidden="true"
+        className="text-[13px] leading-none font-sans-tight tracking-normal"
+      >
+        {display.flag || display.label.slice(0, 2)}
+      </span>
+      <span className="sr-only">{display.label}</span>
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute right-0 bottom-full mb-1 whitespace-nowrap border border-rule-300 dark:border-rule-700 bg-paper-0 dark:bg-paper-950 px-1.5 py-0.5 font-mono-tight text-[10px] normal-case tracking-[0.05em] text-ink-800 dark:text-ink-100 opacity-0 translate-y-0.5 group-hover/flag:opacity-100 group-hover/flag:translate-y-0 group-focus-within/flag:opacity-100 group-focus-within/flag:translate-y-0 transition-[opacity,transform] duration-150 z-10"
+      >
+        {display.label}
+      </span>
+    </span>
+  )
+}

--- a/components/ShishaCard.tsx
+++ b/components/ShishaCard.tsx
@@ -7,6 +7,7 @@ import { MouseEvent } from 'react'
 
 import type { ShishaFlavor } from '../types/shisha'
 
+import CountryFlag from './CountryFlag'
 import NoImage from './NoImage'
 
 interface ShishaCardProps {
@@ -17,26 +18,6 @@ interface ShishaCardProps {
 
 function formatIndex(id: number): string {
   return id.toString().padStart(4, '0')
-}
-
-function countryCode(country?: string): string {
-  if (!country) return 'XX'
-  const map: Record<string, string> = {
-    '日本': 'JP',
-    'アメリカ': 'US',
-    'ドイツ': 'DE',
-    'ロシア': 'RU',
-    'トルコ': 'TR',
-    'ヨルダン': 'JO',
-    'UAE': 'AE',
-    '台湾': 'TW',
-    'エジプト': 'EG',
-    'インドネシア': 'ID',
-    'フランス': 'FR',
-    'イタリア': 'IT',
-    'スペイン': 'ES',
-  }
-  return map[country.trim()] ?? country.slice(0, 2).toUpperCase()
 }
 
 export default function ShishaCard({ flavor, onManufacturerClick, index = 0 }: ShishaCardProps) {
@@ -80,7 +61,7 @@ export default function ShishaCard({ flavor, onManufacturerClick, index = 0 }: S
           <div className="flex items-center justify-between font-mono-tight text-[10px] uppercase tracking-[0.08em] text-ink-500 dark:text-ink-400 nums mb-2">
             <span>№&nbsp;{formatIndex(flavor.id)}</span>
             <span className="flex items-center gap-1.5">
-              <span>{countryCode(flavor.country)}</span>
+              <CountryFlag country={flavor.country} />
               <span className="inline-block w-px h-2.5 bg-rule-300 dark:bg-rule-700" />
               <span>{flavor.amount}</span>
             </span>

--- a/lib/utils/__tests__/countryDisplay.test.ts
+++ b/lib/utils/__tests__/countryDisplay.test.ts
@@ -1,0 +1,65 @@
+import { getCountryDisplay } from '../countryDisplay'
+
+describe('getCountryDisplay', () => {
+  it('returns null for null, undefined, or empty strings', () => {
+    expect(getCountryDisplay(null)).toBeNull()
+    expect(getCountryDisplay(undefined)).toBeNull()
+    expect(getCountryDisplay('')).toBeNull()
+    expect(getCountryDisplay('   ')).toBeNull()
+  })
+
+  it('maps Japanese country names to flag + label', () => {
+    expect(getCountryDisplay('マレーシア')).toEqual({
+      flag: '🇲🇾',
+      label: 'マレーシア',
+      known: true,
+    })
+    expect(getCountryDisplay('ヨルダン')).toEqual({
+      flag: '🇯🇴',
+      label: 'ヨルダン',
+      known: true,
+    })
+  })
+
+  it('maps English variants to the same entry', () => {
+    expect(getCountryDisplay('USA')?.flag).toBe('🇺🇸')
+    expect(getCountryDisplay('USA')?.label).toBe('アメリカ')
+    expect(getCountryDisplay('Jordan')?.flag).toBe('🇯🇴')
+    expect(getCountryDisplay('Germany')?.label).toBe('ドイツ')
+    expect(getCountryDisplay('switzerland')?.flag).toBe('🇨🇭')
+  })
+
+  it('normalises UAE spelling variants', () => {
+    const expected = { flag: '🇦🇪', label: 'アラブ首長国連邦', known: true }
+    expect(getCountryDisplay('UAE')).toEqual(expected)
+    expect(getCountryDisplay('U.A.E')).toEqual(expected)
+    expect(getCountryDisplay('アラブ首長国連邦')).toEqual(expected)
+  })
+
+  it('handles the OCR typo アメリ力合衆国', () => {
+    expect(getCountryDisplay('アメリ力合衆国')).toEqual({
+      flag: '🇺🇸',
+      label: 'アメリカ',
+      known: true,
+    })
+  })
+
+  it('emits two flag glyphs for multi-country entries', () => {
+    const russiaMoldova = getCountryDisplay('ロシアモルドバ')
+    expect(russiaMoldova?.flag).toBe('🇷🇺🇲🇩')
+    expect(russiaMoldova?.label).toBe('ロシア・モルドバ')
+    expect(getCountryDisplay('ロシア モルドバ')?.flag).toBe('🇷🇺🇲🇩')
+  })
+
+  it('trims surrounding whitespace before lookup', () => {
+    expect(getCountryDisplay('  マレーシア  ')?.flag).toBe('🇲🇾')
+  })
+
+  it('returns an unknown entry with the raw label for unmapped values', () => {
+    expect(getCountryDisplay('アトランティス')).toEqual({
+      flag: '',
+      label: 'アトランティス',
+      known: false,
+    })
+  })
+})

--- a/lib/utils/countryDisplay.ts
+++ b/lib/utils/countryDisplay.ts
@@ -1,0 +1,62 @@
+type CountryInfo = { codes: string[]; label: string }
+
+const COUNTRY_MAP: Record<string, CountryInfo> = {
+  'アメリカ合衆国': { codes: ['US'], label: 'アメリカ' },
+  'アメリ力合衆国': { codes: ['US'], label: 'アメリカ' },
+  'USA': { codes: ['US'], label: 'アメリカ' },
+  'ヨルダン': { codes: ['JO'], label: 'ヨルダン' },
+  'Jordan': { codes: ['JO'], label: 'ヨルダン' },
+  'トルコ': { codes: ['TR'], label: 'トルコ' },
+  'アラブ首長国連邦': { codes: ['AE'], label: 'アラブ首長国連邦' },
+  'UAE': { codes: ['AE'], label: 'アラブ首長国連邦' },
+  'U.A.E': { codes: ['AE'], label: 'アラブ首長国連邦' },
+  'ロシア': { codes: ['RU'], label: 'ロシア' },
+  'インドネシア': { codes: ['ID'], label: 'インドネシア' },
+  'switzerland': { codes: ['CH'], label: 'スイス' },
+  'エジプト': { codes: ['EG'], label: 'エジプト' },
+  'マレーシア': { codes: ['MY'], label: 'マレーシア' },
+  'ロシアモルドバ': { codes: ['RU', 'MD'], label: 'ロシア・モルドバ' },
+  'ロシア モルドバ': { codes: ['RU', 'MD'], label: 'ロシア・モルドバ' },
+  'インド': { codes: ['IN'], label: 'インド' },
+  'ドイツ': { codes: ['DE'], label: 'ドイツ' },
+  'Germany': { codes: ['DE'], label: 'ドイツ' },
+  '日本': { codes: ['JP'], label: '日本' },
+  'スペイン': { codes: ['ES'], label: 'スペイン' },
+  'パラグアイ': { codes: ['PY'], label: 'パラグアイ' },
+  'モルドバ': { codes: ['MD'], label: 'モルドバ' },
+  'ラオス': { codes: ['LA'], label: 'ラオス' },
+  '台湾': { codes: ['TW'], label: '台湾' },
+  'フランス': { codes: ['FR'], label: 'フランス' },
+  'イタリア': { codes: ['IT'], label: 'イタリア' },
+}
+
+const REGIONAL_INDICATOR_BASE = 0x1F1E6
+const ASCII_A = 'A'.charCodeAt(0)
+
+function codeToFlag(code: string): string {
+  const upper = code.toUpperCase()
+  if (upper.length !== 2) return ''
+  const codePoints = [...upper].map((ch) => ch.charCodeAt(0) - ASCII_A + REGIONAL_INDICATOR_BASE)
+  return String.fromCodePoint(...codePoints)
+}
+
+export type CountryDisplay = {
+  flag: string
+  label: string
+  known: boolean
+}
+
+export function getCountryDisplay(country?: string | null): CountryDisplay | null {
+  if (!country) return null
+  const key = country.trim()
+  if (!key) return null
+  const info = COUNTRY_MAP[key]
+  if (!info) {
+    return { flag: '', label: key, known: false }
+  }
+  return {
+    flag: info.codes.map(codeToFlag).join(''),
+    label: info.label,
+    known: true,
+  }
+}


### PR DESCRIPTION
## Summary
- 検索一覧のカードで、原産国が 2 文字コード (マレーシア → 「マレ」など意図しない truncation) になっていたのを国旗絵文字に変更。
- hover / focus-within で日本語国名 tooltip を表示 (例: 🇲🇾 → 「マレーシア」、🇦🇪 → 「アラブ首長国連邦」)。
- 実データの 23 country バリエーション (日英混在、「U.A.E」「switzerland」「ロシアモルドバ」、OCR 誤字「アメリ力合衆国」など) を `lib/utils/countryDisplay.ts` のマップで吸収。
- tooltip は Review Ledger 美学に沿って 1px border / zero radius / flat / opacity + translate-y のみのアニメ。

## Test plan
- [x] `pnpm lint`
- [x] `npx tsc --noEmit`
- [x] `pnpm test` (17 passed, うち新規 `countryDisplay` 8 ケース)
- [ ] `pnpm dev` で `/` 一覧を確認し、国旗が出てホバーで国名が浮くこと (ブラウザ側で要確認)
- [ ] モバイル tap での tooltip 挙動を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)