### PR TITLE
Link Brands count stat on home to /brands

### DIFF
--- a/app/ClientHome.tsx
+++ b/app/ClientHome.tsx
@@ -216,14 +216,17 @@ function HomeContent() {
                 {totalResults.toLocaleString()}
               </p>
             </div>
-            <div className="py-6 lg:py-7 px-5 lg:px-10">
-              <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ink-400 dark:text-ink-500 mb-2">
-                Brands
+            <Link
+              href="/brands"
+              className="py-6 lg:py-7 px-5 lg:px-10 block group hover:bg-paper-100 dark:hover:bg-paper-900 transition-colors"
+            >
+              <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ink-400 dark:text-ink-500 mb-2 group-hover:text-ember-500 transition-colors">
+                Brands →
               </p>
               <p className="font-sans-tight font-semibold text-4xl sm:text-5xl lg:text-6xl tracking-[-0.04em] text-ink-950 dark:text-ink-50 nums leading-none">
                 {manufacturers.length}
               </p>
-            </div>
+            </Link>
             <div className="col-span-2 lg:col-span-1 py-6 lg:py-7 px-5 lg:px-10 border-t lg:border-t border-rule-200 dark:border-rule-800">
               <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ink-400 dark:text-ink-500 mb-2">
                 Last refresh

--- a/app/flavor/[id]/FlavorDetailClient.tsx
+++ b/app/flavor/[id]/FlavorDetailClient.tsx
@@ -3,9 +3,9 @@
 import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
-import { MouseEvent } from 'react'
 
 import NoImage from '../../../components/NoImage'
+import { brandSlug } from '../../../lib/utils/brandNormalizer'
 import type { ShishaFlavor } from '../../../types/shisha'
 
 function formatIndex(id: number): string {
@@ -62,8 +62,7 @@ export default function FlavorDetailClient({ flavor }: FlavorDetailClientProps) 
           <div className="col-span-12 md:col-span-5">
             <div className="px-6 md:px-10 py-10">
               <Link
-                href="/"
-                onClick={(e: MouseEvent<HTMLAnchorElement>) => { e.preventDefault(); window.history.back() }}
+                href={`/brands/${brandSlug(flavor.manufacturer)}`}
                 className="font-mono-tight text-[10px] uppercase tracking-[0.18em] text-ember-500 hover:text-ember-600 transition-colors block mb-4"
               >
                 {flavor.manufacturer}

--- a/components/ShishaCard.tsx
+++ b/components/ShishaCard.tsx
@@ -3,8 +3,10 @@
 import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { MouseEvent } from 'react'
 
+import { brandSlug } from '../lib/utils/brandNormalizer'
 import type { ShishaFlavor } from '../types/shisha'
 
 import CountryFlag from './CountryFlag'
@@ -21,10 +23,15 @@ function formatIndex(id: number): string {
 }
 
 export default function ShishaCard({ flavor, onManufacturerClick, index = 0 }: ShishaCardProps) {
+  const router = useRouter()
+
   const handleManufacturerClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
+    e.stopPropagation()
     if (onManufacturerClick) {
       onManufacturerClick(flavor.manufacturer)
+    } else {
+      router.push(`/brands/${brandSlug(flavor.manufacturer)}`)
     }
   }
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -5,6 +5,19 @@ import 'jest-fetch-mock'
 const mockFetch = require('jest-fetch-mock')
 global.fetch = mockFetch
 
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/',
+}))
+
 beforeEach(() => {
   mockFetch.resetMocks()
 })


### PR DESCRIPTION
Make the Brands count tile in the hero aside tappable — it now
routes to the brand index page, matching the existing "Brand
Index →" masthead link.