### PR TITLE
Enrich home page with editorial sections

### DIFF
--- a/app/ClientHome.tsx
+++ b/app/ClientHome.tsx
@@ -3,7 +3,7 @@
 import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { useSearchParams, useRouter } from 'next/navigation'
-import { useState, useEffect, Suspense } from 'react'
+import { useState, useEffect, Suspense, type ReactNode } from 'react'
 
 import BrandList from '../components/BrandList'
 import LoadingSpinner from '../components/LoadingSpinner'
@@ -19,7 +19,11 @@ interface SearchParams {
   searchType?: 'all' | 'brand' | 'flavor'
 }
 
-function HomeContent() {
+interface HomeContentProps {
+  editorialSections?: ReactNode
+}
+
+function HomeContent({ editorialSections }: HomeContentProps) {
   const searchParams = useSearchParams()
   const router = useRouter()
 
@@ -238,6 +242,13 @@ function HomeContent() {
           </aside>
         </motion.section>
 
+        {/* Editorial sections (Featured / Latest / Origins / Editor's Picks) */}
+        {!searchQuery && !selectedManufacturer && editorialSections && (
+          <section aria-label="Editorial">
+            {editorialSections}
+          </section>
+        )}
+
         {/* Controls */}
         <section className="py-10">
           <SearchBar
@@ -257,7 +268,7 @@ function HomeContent() {
         {/* Results header */}
         <div className="flex items-baseline justify-between border-t border-ink-900 dark:border-ink-100 border-b border-rule-200 dark:border-rule-800 py-3 mb-0 font-mono-tight text-[10px] uppercase tracking-[0.16em] text-ink-600 dark:text-ink-300">
           <span className="flex items-center gap-3">
-            <span className="text-ember-500">§</span>
+            <span className="text-ember-500 nums">§&nbsp;006</span>
             <span>Entries</span>
           </span>
           <span className="nums">
@@ -349,14 +360,18 @@ function HomeContent() {
   )
 }
 
-export default function ClientHome() {
+interface ClientHomeProps {
+  children?: ReactNode
+}
+
+export default function ClientHome({ children }: ClientHomeProps) {
   return (
     <Suspense fallback={
       <div className="min-h-screen flex justify-center items-center bg-paper-0 dark:bg-paper-950">
         <LoadingSpinner />
       </div>
     }>
-      <HomeContent />
+      <HomeContent editorialSections={children} />
     </Suspense>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,10 @@
 import ClientHome from './ClientHome'
+import HomeSections from '../components/home/HomeSections'
 
 export default function Home() {
-  return <ClientHome />
+  return (
+    <ClientHome>
+      <HomeSections />
+    </ClientHome>
+  )
 }

--- a/components/home/EditorsPicks.tsx
+++ b/components/home/EditorsPicks.tsx
@@ -1,0 +1,88 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+import { brandSlug } from '../../lib/utils/brandNormalizer'
+import type { EditorsPickFlavor } from '../../data/homeSections'
+import NoImage from '../NoImage'
+
+import SectionHeader from './SectionHeader'
+
+interface EditorsPicksProps {
+  picks: EditorsPickFlavor[]
+}
+
+export default function EditorsPicks({ picks }: EditorsPicksProps) {
+  if (picks.length === 0) return null
+
+  return (
+    <section className="mt-16">
+      <SectionHeader
+        section="§ 005"
+        title="Editor's Selection"
+        subtitle={`${picks.length} entries · hand-picked · with notes`}
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-0 border-b border-rule-200 dark:border-rule-800">
+        {picks.map(({ flavor, note }, idx) => {
+          const hasImg = Boolean(flavor.imageUrl && flavor.imageUrl.trim() !== '')
+          const isRightCol = idx % 2 === 1
+          const isNotLast = idx < picks.length - 1
+          const isLastRow = idx >= picks.length - 2
+          return (
+            <article
+              key={flavor.id}
+              className={`group flex items-start gap-4 p-5 border-rule-200 dark:border-rule-800 ${
+                !isRightCol ? 'md:border-r' : ''
+              } ${isNotLast ? 'border-b' : ''} ${isLastRow ? 'md:border-b-0' : 'md:border-b'}`}
+            >
+              <Link
+                href={`/flavor/${flavor.id}`}
+                className="relative w-28 h-28 shrink-0 bg-paper-100 dark:bg-paper-900 border border-rule-200 dark:border-rule-800 overflow-hidden"
+              >
+                {hasImg ? (
+                  <Image
+                    src={flavor.imageUrl}
+                    alt={flavor.productName}
+                    fill
+                    sizes="112px"
+                    className="object-cover transition-transform duration-300 ease-out group-hover:scale-[1.02]"
+                  />
+                ) : (
+                  <NoImage />
+                )}
+              </Link>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline gap-2 font-mono-tight text-[10px] uppercase tracking-[0.1em] text-ink-500 dark:text-ink-400 nums mb-1.5">
+                  <span className="text-ember-500">№&nbsp;{String(idx + 1).padStart(2, '0')}</span>
+                  <span>·</span>
+                  <Link
+                    href={`/brands/${brandSlug(flavor.manufacturer)}`}
+                    className="hover:text-ember-500 transition-colors truncate"
+                  >
+                    {flavor.manufacturer}
+                  </Link>
+                </div>
+                <Link
+                  href={`/flavor/${flavor.id}`}
+                  className="block font-sans-tight font-semibold text-base sm:text-lg leading-[1.2] text-ink-950 dark:text-ink-50 group-hover:text-ember-500 transition-colors line-clamp-2 mb-2"
+                >
+                  {flavor.productName}
+                </Link>
+                {note && (
+                  <p className="font-sans-tight text-sm text-ink-600 dark:text-ink-300 leading-[1.5] line-clamp-2">
+                    {note}
+                  </p>
+                )}
+                <div className="flex items-center gap-2 mt-3 font-mono-tight text-[10px] uppercase tracking-[0.12em] text-ink-400 dark:text-ink-500 nums">
+                  <span>{flavor.amount}</span>
+                  <span className="inline-block w-px h-2.5 bg-rule-300 dark:bg-rule-700" />
+                  <span>{flavor.price}</span>
+                </div>
+              </div>
+            </article>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/components/home/FeaturedBrands.tsx
+++ b/components/home/FeaturedBrands.tsx
@@ -1,0 +1,65 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+import type { FeaturedBrand } from '../../data/homeSections'
+
+import SectionHeader from './SectionHeader'
+
+interface FeaturedBrandsProps {
+  brands: FeaturedBrand[]
+}
+
+export default function FeaturedBrands({ brands }: FeaturedBrandsProps) {
+  if (brands.length === 0) return null
+
+  return (
+    <section className="mt-16">
+      <SectionHeader
+        section="§ 002"
+        title="Featured Houses"
+        subtitle="editor-verified brands with notes & logo"
+        linkHref="/brands"
+        linkLabel="all brands"
+      />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-0 border-b border-rule-200 dark:border-rule-800">
+        {brands.map((brand, idx) => (
+          <Link
+            key={brand.slug}
+            href={`/brands/${brand.slug}`}
+            className={`group relative flex flex-col p-5 border-rule-200 dark:border-rule-800 transition-colors hover:bg-paper-50 dark:hover:bg-paper-900 ${
+              idx % 4 !== 3 ? 'lg:border-r' : ''
+            } ${idx % 2 !== 1 ? 'sm:border-r lg:border-r' : 'sm:border-r-0 lg:border-r'} ${
+              idx < brands.length - 1 ? 'border-b sm:border-b' : ''
+            } ${idx < brands.length - 2 ? 'sm:border-b' : 'sm:border-b-0'} ${
+              idx < brands.length - 4 ? 'lg:border-b' : 'lg:border-b-0'
+            }`}
+          >
+            <div className="flex items-start justify-between gap-3 mb-4">
+              <div className="relative h-12 w-20 shrink-0 bg-paper-50 dark:bg-paper-900 border border-rule-200 dark:border-rule-800">
+                <Image
+                  src={brand.imageUrl as string}
+                  alt={`${brand.name} logo`}
+                  fill
+                  sizes="80px"
+                  className="object-contain p-1.5"
+                />
+              </div>
+              <span className="font-mono-tight text-[10px] uppercase tracking-[0.1em] text-ember-500 nums shrink-0 pt-1">
+                {String(brand.count).padStart(3, '0')}&nbsp;ENT.
+              </span>
+            </div>
+            <h3 className="font-sans-tight font-semibold text-lg tracking-[-0.01em] text-ink-950 dark:text-ink-50 group-hover:text-ember-500 transition-colors mb-1.5">
+              {brand.name}
+            </h3>
+            <p className="font-sans-tight text-sm leading-[1.45] text-ink-600 dark:text-ink-300 line-clamp-3">
+              {brand.description}
+            </p>
+            <span className="font-mono-tight text-[10px] uppercase tracking-[0.14em] text-ink-400 dark:text-ink-500 group-hover:text-ember-500 transition-colors mt-4">
+              view catalog →
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/home/FeaturedBrands.tsx
+++ b/components/home/FeaturedBrands.tsx
@@ -21,40 +21,34 @@ export default function FeaturedBrands({ brands }: FeaturedBrandsProps) {
         linkHref="/brands"
         linkLabel="all brands"
       />
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-0 border-b border-rule-200 dark:border-rule-800">
-        {brands.map((brand, idx) => (
+      <div className="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-rule-200 dark:divide-rule-800 border-b border-rule-200 dark:border-rule-800">
+        {brands.map((brand) => (
           <Link
             key={brand.slug}
             href={`/brands/${brand.slug}`}
-            className={`group relative flex flex-col p-5 border-rule-200 dark:border-rule-800 transition-colors hover:bg-paper-50 dark:hover:bg-paper-900 ${
-              idx % 4 !== 3 ? 'lg:border-r' : ''
-            } ${idx % 2 !== 1 ? 'sm:border-r lg:border-r' : 'sm:border-r-0 lg:border-r'} ${
-              idx < brands.length - 1 ? 'border-b sm:border-b' : ''
-            } ${idx < brands.length - 2 ? 'sm:border-b' : 'sm:border-b-0'} ${
-              idx < brands.length - 4 ? 'lg:border-b' : 'lg:border-b-0'
-            }`}
+            className="group flex flex-col p-6 transition-colors hover:bg-paper-50 dark:hover:bg-paper-900"
           >
-            <div className="flex items-start justify-between gap-3 mb-4">
-              <div className="relative h-12 w-20 shrink-0 bg-paper-50 dark:bg-paper-900 border border-rule-200 dark:border-rule-800">
+            <div className="flex items-start justify-between gap-3 mb-5">
+              <div className="relative h-14 w-24 shrink-0 bg-paper-50 dark:bg-paper-900 border border-rule-200 dark:border-rule-800">
                 <Image
                   src={brand.imageUrl as string}
                   alt={`${brand.name} logo`}
                   fill
-                  sizes="80px"
-                  className="object-contain p-1.5"
+                  sizes="96px"
+                  className="object-contain p-2"
                 />
               </div>
               <span className="font-mono-tight text-[10px] uppercase tracking-[0.1em] text-ember-500 nums shrink-0 pt-1">
                 {String(brand.count).padStart(3, '0')}&nbsp;ENT.
               </span>
             </div>
-            <h3 className="font-sans-tight font-semibold text-lg tracking-[-0.01em] text-ink-950 dark:text-ink-50 group-hover:text-ember-500 transition-colors mb-1.5">
+            <h3 className="font-sans-tight font-semibold text-lg tracking-[-0.01em] text-ink-950 dark:text-ink-50 group-hover:text-ember-500 transition-colors mb-2">
               {brand.name}
             </h3>
-            <p className="font-sans-tight text-sm leading-[1.45] text-ink-600 dark:text-ink-300 line-clamp-3">
+            <p className="font-sans-tight text-sm leading-[1.5] text-ink-600 dark:text-ink-300 line-clamp-3">
               {brand.description}
             </p>
-            <span className="font-mono-tight text-[10px] uppercase tracking-[0.14em] text-ink-400 dark:text-ink-500 group-hover:text-ember-500 transition-colors mt-4">
+            <span className="font-mono-tight text-[10px] uppercase tracking-[0.14em] text-ink-400 dark:text-ink-500 group-hover:text-ember-500 transition-colors mt-5">
               view catalog →
             </span>
           </Link>

--- a/components/home/HomeSections.tsx
+++ b/components/home/HomeSections.tsx
@@ -17,7 +17,7 @@ import OriginShelf from './OriginShelf'
  * handed to child components as plain props.
  */
 export default function HomeSections() {
-  const featuredBrands = getFeaturedBrands(8)
+  const featuredBrands = getFeaturedBrands(3)
   const latestFlavors = getLatestFlavors(8)
   const originBuckets = getOriginBuckets(6)
   const editorsPicks = getEditorsPicks()

--- a/components/home/HomeSections.tsx
+++ b/components/home/HomeSections.tsx
@@ -1,0 +1,33 @@
+import {
+  getEditorsPicks,
+  getFeaturedBrands,
+  getLatestFlavors,
+  getOriginBuckets,
+} from '../../data/homeSections'
+
+import EditorsPicks from './EditorsPicks'
+import FeaturedBrands from './FeaturedBrands'
+import LatestFlavors from './LatestFlavors'
+import OriginShelf from './OriginShelf'
+
+/**
+ * Server component that assembles the curated editorial sections shown
+ * on the home page between the hero and the search grid. All data is
+ * pulled from shishaData at request time (cheap — pure in-memory) and
+ * handed to child components as plain props.
+ */
+export default function HomeSections() {
+  const featuredBrands = getFeaturedBrands(8)
+  const latestFlavors = getLatestFlavors(8)
+  const originBuckets = getOriginBuckets(6)
+  const editorsPicks = getEditorsPicks()
+
+  return (
+    <>
+      <FeaturedBrands brands={featuredBrands} />
+      <LatestFlavors flavors={latestFlavors} />
+      <OriginShelf buckets={originBuckets} />
+      <EditorsPicks picks={editorsPicks} />
+    </>
+  )
+}

--- a/components/home/LatestFlavors.tsx
+++ b/components/home/LatestFlavors.tsx
@@ -1,0 +1,27 @@
+import ShishaCard from '../ShishaCard'
+import type { ShishaFlavor } from '../../types/shisha'
+
+import SectionHeader from './SectionHeader'
+
+interface LatestFlavorsProps {
+  flavors: ShishaFlavor[]
+}
+
+export default function LatestFlavors({ flavors }: LatestFlavorsProps) {
+  if (flavors.length === 0) return null
+
+  return (
+    <section className="mt-16">
+      <SectionHeader
+        section="§ 003"
+        title="Latest Additions"
+        subtitle={`most recently indexed, ${flavors.length} imaged entries`}
+      />
+      <div className="pt-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {flavors.map((flavor, idx) => (
+          <ShishaCard key={flavor.id} flavor={flavor} index={idx} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/home/OriginShelf.tsx
+++ b/components/home/OriginShelf.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { motion, AnimatePresence } from 'framer-motion'
+import { useState } from 'react'
+
+import ShishaCard from '../ShishaCard'
+import type { OriginBucket } from '../../data/homeSections'
+
+import SectionHeader from './SectionHeader'
+
+interface OriginShelfProps {
+  buckets: OriginBucket[]
+}
+
+export default function OriginShelf({ buckets }: OriginShelfProps) {
+  const [activeCode, setActiveCode] = useState(buckets[0]?.code ?? '')
+  const active = buckets.find(b => b.code === activeCode) ?? buckets[0]
+
+  if (!active) return null
+
+  return (
+    <section className="mt-16">
+      <SectionHeader
+        section="§ 004"
+        title="Origins"
+        subtitle={`production country · top ${buckets.length} clusters`}
+      />
+
+      <div className="flex flex-wrap gap-0 border-b border-rule-200 dark:border-rule-800">
+        {buckets.map((bucket) => {
+          const isActive = bucket.code === active.code
+          return (
+            <button
+              key={bucket.code}
+              type="button"
+              onClick={() => setActiveCode(bucket.code)}
+              className={`flex items-center gap-2 px-4 py-3 font-mono-tight text-[11px] uppercase tracking-[0.14em] transition-colors border-r border-rule-200 dark:border-rule-800 ${
+                isActive
+                  ? 'bg-ink-900 text-paper-0 dark:bg-ink-100 dark:text-paper-950'
+                  : 'text-ink-500 dark:text-ink-400 hover:text-ember-500'
+              }`}
+            >
+              <span className="text-base leading-none" aria-hidden>{bucket.flag}</span>
+              <span>{bucket.label}</span>
+              <span className="nums opacity-70 text-[10px]">{bucket.total.toLocaleString()}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={active.code}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="pt-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4"
+        >
+          {active.flavors.map((flavor, idx) => (
+            <ShishaCard key={flavor.id} flavor={flavor} index={idx} />
+          ))}
+        </motion.div>
+      </AnimatePresence>
+    </section>
+  )
+}

--- a/components/home/SectionHeader.tsx
+++ b/components/home/SectionHeader.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+
+interface SectionHeaderProps {
+  section: string
+  title: string
+  subtitle?: string
+  linkHref?: string
+  linkLabel?: string
+}
+
+export default function SectionHeader({ section, title, subtitle, linkHref, linkLabel }: SectionHeaderProps) {
+  return (
+    <div className="flex items-end justify-between gap-4 border-t border-ink-900 dark:border-ink-100 border-b border-rule-200 dark:border-rule-800 py-3">
+      <div className="min-w-0">
+        <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ember-500 mb-1 nums">
+          {section}
+        </p>
+        <h2 className="font-sans-tight font-semibold text-xl sm:text-2xl tracking-[-0.02em] text-ink-950 dark:text-ink-50 truncate">
+          {title}
+        </h2>
+        {subtitle && (
+          <p className="font-mono-tight text-[10px] uppercase tracking-[0.14em] text-ink-500 dark:text-ink-400 mt-1 truncate">
+            {subtitle}
+          </p>
+        )}
+      </div>
+      {linkHref && linkLabel && (
+        <Link
+          href={linkHref}
+          className="shrink-0 font-mono-tight text-[10px] uppercase tracking-[0.16em] text-ink-600 dark:text-ink-300 hover:text-ember-500 transition-colors whitespace-nowrap pb-1"
+        >
+          {linkLabel} →
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/data/curatedPicks.ts
+++ b/data/curatedPicks.ts
@@ -1,0 +1,25 @@
+/**
+ * 編集部による手選びフレーバー。トップページ § 005 「Editor's Selection」で使用。
+ *
+ * - `id` は shishaData の id と一致させる
+ * - `note` は 1 行の日本語短評 (省略可。無いときはカードのみ表示)
+ * - 画像が public/images/flavors/<id>.<ext> にあるもの優先で選ぶと見栄えが良い
+ * - 並び順がそのまま UI の表示順
+ */
+export interface CuratedPick {
+  id: number
+  note?: string
+}
+
+export const EDITORS_PICKS: CuratedPick[] = [
+  { id: 134, note: 'Al Fakher の原点。りんごは全ての基準点。' },
+  { id: 1603, note: 'ダークリーフ × シリアルの異色作。甘さの底に焦げが走る。' },
+  { id: 2531, note: 'Fumari のフレッシュ製法が映えるトロピカル。' },
+  { id: 4003, note: '国産 Samurai Blond のシグネチャ。アーモンドの香ばしさ。' },
+  { id: 4745, note: 'Tangiers 2005 復刻。ブルーベリーの酸の立ち方が別物。' },
+  { id: 2218, note: 'DOZAJ のパンチが効く、ベリー系の入口。' },
+  { id: 5014, note: 'Trifecta のブロンド葉、りんご軸の定番。' },
+  { id: 2342, note: 'Eternal Smoke の夜向けブレンド。' },
+  { id: 3887, note: 'Romman のハンドメイド 125g 缶。アーモンドの厚み。' },
+  { id: 1313, note: 'Buta のハニーベース。アサイーの抜け感が良い。' },
+]

--- a/data/homeSections.ts
+++ b/data/homeSections.ts
@@ -1,0 +1,145 @@
+import { BRAND_DESCRIPTIONS } from './brandDescriptions'
+import { getBrandImageUrl } from './brandImages'
+import { EDITORS_PICKS } from './curatedPicks'
+import { resolveFlavorImage } from './flavorImages'
+import { shishaData } from './shishaData'
+import { brandSlug, getUniqueBrands, normalizeBrandForSearch, normalizeBrandName } from '../lib/utils/brandNormalizer'
+import { getCountryDisplay } from '../lib/utils/countryDisplay'
+import type { ShishaFlavor } from '../types/shisha'
+
+/**
+ * Server-only helpers for the home page editorial sections.
+ * Imports `data/brandImages` / `data/flavorImages` which use `node:fs`,
+ * so this module must only be consumed from server components.
+ */
+
+export interface FeaturedBrand {
+  name: string
+  slug: string
+  description: string
+  imageUrl?: string
+  count: number
+}
+
+export interface OriginBucket {
+  code: string
+  label: string
+  flag: string
+  total: number
+  flavors: ShishaFlavor[]
+}
+
+export interface EditorsPickFlavor {
+  flavor: ShishaFlavor
+  note?: string
+}
+
+function hasImage(flavor: ShishaFlavor): boolean {
+  if (flavor.imageUrl && flavor.imageUrl.trim() !== '') return true
+  const resolved = resolveFlavorImage(flavor)
+  return Boolean(resolved.imageUrl && resolved.imageUrl.trim() !== '')
+}
+
+function countByBrand(): Map<string, { displayName: string; count: number }> {
+  const counts = new Map<string, { displayName: string; count: number }>()
+  for (const item of shishaData) {
+    const key = normalizeBrandForSearch(item.manufacturer)
+    const entry = counts.get(key)
+    if (entry) {
+      entry.count += 1
+    } else {
+      counts.set(key, { displayName: normalizeBrandName(item.manufacturer), count: 1 })
+    }
+  }
+  return counts
+}
+
+/**
+ * Picks up to `limit` brands that have BOTH a hand-written description
+ * and a local logo, ordered by flavor count (descending).
+ */
+export function getFeaturedBrands(limit = 8): FeaturedBrand[] {
+  const counts = countByBrand()
+  const candidates: FeaturedBrand[] = []
+
+  for (const name of getUniqueBrands(shishaData.map(i => i.manufacturer))) {
+    const slug = brandSlug(name)
+    const description = BRAND_DESCRIPTIONS[slug]
+    const imageUrl = getBrandImageUrl(name)
+    if (!description || !imageUrl) continue
+    const entry = counts.get(normalizeBrandForSearch(name))
+    candidates.push({
+      name,
+      slug,
+      description,
+      imageUrl,
+      count: entry?.count ?? 0,
+    })
+  }
+
+  candidates.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+  return candidates.slice(0, limit)
+}
+
+/**
+ * Returns the most recently indexed flavors (highest ids) that have an
+ * image available, capped at `limit`. Falls back to the raw tail when
+ * fewer than `limit` imaged entries exist.
+ */
+export function getLatestFlavors(limit = 8): ShishaFlavor[] {
+  const picked: ShishaFlavor[] = []
+  for (let i = shishaData.length - 1; i >= 0 && picked.length < limit; i--) {
+    const resolved = resolveFlavorImage(shishaData[i])
+    if (hasImage(resolved)) picked.push(resolved)
+  }
+  if (picked.length < limit) {
+    for (let i = shishaData.length - 1; i >= 0 && picked.length < limit; i--) {
+      if (picked.find(p => p.id === shishaData[i].id)) continue
+      picked.push(resolveFlavorImage(shishaData[i]))
+    }
+  }
+  return picked
+}
+
+const ORIGIN_ORDER: Array<{ code: string; keys: string[] }> = [
+  { code: 'US', keys: ['アメリカ合衆国', 'USA', 'アメリ力合衆国'] },
+  { code: 'JO', keys: ['ヨルダン', 'Jordan'] },
+  { code: 'TR', keys: ['トルコ'] },
+  { code: 'AE', keys: ['アラブ首長国連邦', 'UAE', 'U.A.E'] },
+  { code: 'RU', keys: ['ロシア'] },
+]
+
+export function getOriginBuckets(perBucket = 6): OriginBucket[] {
+  const buckets: OriginBucket[] = []
+  for (const { code, keys } of ORIGIN_ORDER) {
+    const all = shishaData.filter(f => keys.includes(f.country))
+    const imaged: ShishaFlavor[] = []
+    const others: ShishaFlavor[] = []
+    for (const f of all) {
+      const resolved = resolveFlavorImage(f)
+      if (hasImage(resolved)) imaged.push(resolved)
+      else others.push(resolved)
+    }
+    const flavors = [...imaged, ...others].slice(0, perBucket)
+    const display = getCountryDisplay(keys[0])
+    buckets.push({
+      code,
+      label: display?.label ?? keys[0],
+      flag: display?.flag ?? '',
+      total: all.length,
+      flavors,
+    })
+  }
+  return buckets
+}
+
+export function getEditorsPicks(): EditorsPickFlavor[] {
+  const byId = new Map(shishaData.map(f => [f.id, f] as const))
+  const picks: EditorsPickFlavor[] = []
+  for (const { id, note } of EDITORS_PICKS) {
+    const flavor = byId.get(id)
+    if (!flavor) continue
+    picks.push({ flavor: resolveFlavorImage(flavor), note })
+  }
+  return picks
+}


### PR DESCRIPTION
Hero now sits above four curated shelves — Featured Houses, Latest
Additions, Origins, and Editor's Selection — giving readers multiple
entry points beyond the search box. Sections hide when a search or brand
filter is active so the results grid stays primary.

- data/homeSections.ts aggregates picks from shishaData server-side
- data/curatedPicks.ts holds hand-maintained editor picks + notes
- components/home/* renders each shelf in the existing ledger style
- OriginShelf is a client component with country tabs; the rest are
  plain server components feeding ShishaCard

https://claude.ai/code/session_01HHoZN4ZJhzBg1G41a2mKTU