### PR TITLE
perf: Lighthouse Performance 61→83、LCP 7.1s→1.8s 改善

### DIFF
--- a/app/ClientHome.tsx
+++ b/app/ClientHome.tsx
@@ -6,7 +6,7 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import { useState, useEffect, Suspense, type ReactNode } from 'react'
 
 import BrandList from '../components/BrandList'
-import LoadingSpinner from '../components/LoadingSpinner'
+import HeroFallback from '../components/home/HeroFallback'
 import SearchBar from '../components/SearchBar'
 import ShishaCard from '../components/ShishaCard'
 import SkeletonGrid from '../components/SkeletonGrid'
@@ -22,23 +22,26 @@ interface SearchParams {
 interface HomeContentProps {
   editorialSections?: ReactNode
   lastDataUpdated?: string | null
+  initialManufacturers?: string[]
+  initialTotalItems?: number
 }
 
-function HomeContent({ editorialSections, lastDataUpdated }: HomeContentProps) {
+function HomeContent({ editorialSections, lastDataUpdated, initialManufacturers = [], initialTotalItems = 0 }: HomeContentProps) {
   const searchParams = useSearchParams()
   const router = useRouter()
 
   const [flavors, setFlavors] = useState<ShishaFlavor[]>([])
   const [loading, setLoading] = useState(false)
   const [isSearching, setIsSearching] = useState(false)
-  const [manufacturers, setManufacturers] = useState<string[]>([])
+  const [manufacturers, setManufacturers] = useState<string[]>(initialManufacturers)
   const [currentPage, setCurrentPage] = useState(parseInt(searchParams.get('page') || '1'))
   const [totalPages, setTotalPages] = useState(0)
-  const [totalResults, setTotalResults] = useState(0)
+  const [totalResults, setTotalResults] = useState(initialTotalItems)
   const [selectedManufacturer, setSelectedManufacturer] = useState(searchParams.get('manufacturer') || '')
   const [searchQuery, setSearchQuery] = useState(searchParams.get('query') || '')
 
   useEffect(() => {
+    if (initialManufacturers.length > 0) return
     const fetchManufacturers = async () => {
       try {
         const response = await fetch('/api/manufacturers')
@@ -49,7 +52,7 @@ function HomeContent({ editorialSections, lastDataUpdated }: HomeContentProps) {
       }
     }
     fetchManufacturers()
-  }, [])
+  }, [initialManufacturers.length])
 
   const handleSearch = async ({ query = '', manufacturer = undefined, page = undefined, searchType = 'all' }: SearchParams) => {
     try {
@@ -178,12 +181,7 @@ function HomeContent({ editorialSections, lastDataUpdated }: HomeContentProps) {
         </header>
 
         {/* Hero */}
-        <motion.section
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.35 }}
-          className="grid grid-cols-12 gap-0 border-b border-ink-900 dark:border-ink-100"
-        >
+        <section className="grid grid-cols-12 gap-0 border-b border-ink-900 dark:border-ink-100">
           <div className="col-span-12 lg:col-span-8 lg:border-r lg:border-rule-200 lg:dark:border-rule-800 py-10 lg:py-14 lg:pr-10">
             <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ember-500 mb-5">
               § 001 · The Ledger
@@ -243,7 +241,7 @@ function HomeContent({ editorialSections, lastDataUpdated }: HomeContentProps) {
               </div>
             )}
           </aside>
-        </motion.section>
+        </section>
 
         {/* Editorial sections (Featured / Latest / Origins / Editor's Picks) */}
         {!searchQuery && !selectedManufacturer && editorialSections && (
@@ -366,16 +364,25 @@ function HomeContent({ editorialSections, lastDataUpdated }: HomeContentProps) {
 interface ClientHomeProps {
   children?: ReactNode
   lastDataUpdated?: string | null
+  initialManufacturers?: string[]
+  initialTotalItems?: number
 }
 
-export default function ClientHome({ children, lastDataUpdated }: ClientHomeProps) {
+export default function ClientHome({ children, lastDataUpdated, initialManufacturers = [], initialTotalItems = 0 }: ClientHomeProps) {
   return (
     <Suspense fallback={
-      <div className="min-h-screen flex justify-center items-center bg-paper-0 dark:bg-paper-950">
-        <LoadingSpinner />
-      </div>
+      <HeroFallback
+        initialTotalItems={initialTotalItems}
+        initialBrandsCount={initialManufacturers.length}
+        lastDataUpdated={lastDataUpdated ?? null}
+      />
     }>
-      <HomeContent editorialSections={children} lastDataUpdated={lastDataUpdated} />
+      <HomeContent
+        editorialSections={children}
+        lastDataUpdated={lastDataUpdated}
+        initialManufacturers={initialManufacturers}
+        initialTotalItems={initialTotalItems}
+      />
     </Suspense>
   )
 }

--- a/app/brands/BrandsClient.tsx
+++ b/app/brands/BrandsClient.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { motion } from 'framer-motion'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
 
@@ -59,12 +58,7 @@ export default function BrandsClient({ brands }: BrandsClientProps) {
         </header>
 
         {/* Hero */}
-        <motion.section
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.35 }}
-          className="grid grid-cols-12 gap-0 border-b border-ink-900 dark:border-ink-100"
-        >
+        <section className="grid grid-cols-12 gap-0 border-b border-ink-900 dark:border-ink-100">
           <div className="col-span-12 lg:col-span-8 lg:border-r lg:border-rule-200 lg:dark:border-rule-800 py-10 lg:py-14 lg:pr-10">
             <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ember-500 mb-5">
               § 002 · The Brands
@@ -110,7 +104,7 @@ export default function BrandsClient({ brands }: BrandsClientProps) {
               </p>
             </div>
           </aside>
-        </motion.section>
+        </section>
 
         {/* Controls */}
         <section className="py-10 grid grid-cols-12 gap-4 border-b border-rule-200 dark:border-rule-800">

--- a/app/brands/[slug]/BrandDetailClient.tsx
+++ b/app/brands/[slug]/BrandDetailClient.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
@@ -59,12 +58,7 @@ export default function BrandDetailClient({ slug, brandName, flavors, imageUrl, 
         </header>
 
         {/* Hero */}
-        <motion.section
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.25 }}
-          className="grid grid-cols-12 gap-0 border-b border-ink-900 dark:border-ink-100"
-        >
+        <section className="grid grid-cols-12 gap-0 border-b border-ink-900 dark:border-ink-100">
           <div className="col-span-12 md:col-span-8 md:border-r md:border-rule-200 md:dark:border-rule-800 py-10 lg:py-14 md:pr-10">
             <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ember-500 mb-5">
               § Brand · {flavors.length} flavors on file
@@ -109,6 +103,7 @@ export default function BrandDetailClient({ slug, brandName, flavors, imageUrl, 
                   src={imageUrl as string}
                   alt={`${brandName} logo`}
                   fill
+                  priority
                   className="object-contain p-8 sm:p-10"
                   sizes="(max-width: 768px) 100vw, 33vw"
                   onError={() => setImageError(true)}
@@ -140,7 +135,7 @@ export default function BrandDetailClient({ slug, brandName, flavors, imageUrl, 
               </div>
             </div>
           </aside>
-        </motion.section>
+        </section>
 
         {/* In-brand search */}
         <div className="mt-10 border-b border-rule-200 dark:border-rule-800">

--- a/app/flavor/[id]/FlavorDetailClient.tsx
+++ b/app/flavor/[id]/FlavorDetailClient.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
 
@@ -34,12 +33,7 @@ export default function FlavorDetailClient({ flavor, related = [] }: FlavorDetai
         </header>
 
         {/* Entry */}
-        <motion.article
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.25 }}
-          className="grid grid-cols-12 gap-0 border-b border-ink-900 dark:border-ink-100"
-        >
+        <article className="grid grid-cols-12 gap-0 border-b border-ink-900 dark:border-ink-100">
           <figure className="col-span-12 md:col-span-7 md:border-r border-rule-200 dark:border-rule-800 relative bg-paper-50 dark:bg-paper-900">
             <div className="relative aspect-[3/4] md:aspect-auto md:h-full md:min-h-[640px]">
               {flavor.imageUrl ? (
@@ -52,7 +46,7 @@ export default function FlavorDetailClient({ flavor, related = [] }: FlavorDetai
                   priority
                 />
               ) : (
-                <NoImage label="No image on file" />
+                <NoImage label="No image on file" priority />
               )}
             </div>
             <figcaption className="absolute bottom-0 left-0 right-0 px-4 py-2 border-t border-rule-200 dark:border-rule-800 bg-paper-0/95 dark:bg-paper-950/95 backdrop-blur-sm font-mono-tight text-[10px] uppercase tracking-[0.14em] text-ink-500 dark:text-ink-400 flex items-center justify-between nums">
@@ -119,7 +113,7 @@ export default function FlavorDetailClient({ flavor, related = [] }: FlavorDetai
               </div>
             </div>
           </div>
-        </motion.article>
+        </article>
 
         {related.length > 0 && (
           <section className="mt-16">

--- a/app/globals.css
+++ b/app/globals.css
@@ -138,4 +138,14 @@
   .animate-sweep {
     animation: sweep 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
   }
+
+  /* Card stagger fade-in (replaces Framer Motion per-card animation) */
+  @keyframes card-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+  .animate-card-in {
+    animation: card-fade-in 0.25s ease-out both;
+    animation-delay: var(--card-delay, 0ms);
+  }
 }

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#e8492c"/>
+  <rect x="6" y="14" width="20" height="2" fill="white"/>
+  <rect x="6" y="19" width="14" height="2" fill="white"/>
+  <rect x="6" y="9" width="20" height="2" fill="white"/>
+</svg>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@ import path from 'node:path'
 
 import ClientHome from './ClientHome'
 import HomeSections from '../components/home/HomeSections'
+import { getManufacturers } from '../data/shishaMethods'
+import { shishaData } from '../data/shishaData'
 
 function getLastDataUpdated(): string | null {
   try {
@@ -19,8 +21,14 @@ function getLastDataUpdated(): string | null {
 
 export default function Home() {
   const lastDataUpdated = getLastDataUpdated()
+  const initialManufacturers = getManufacturers()
+  const initialTotalItems = (shishaData as unknown[]).length
   return (
-    <ClientHome lastDataUpdated={lastDataUpdated}>
+    <ClientHome
+      lastDataUpdated={lastDataUpdated}
+      initialManufacturers={initialManufacturers}
+      initialTotalItems={initialTotalItems}
+    >
       <HomeSections />
     </ClientHome>
   )

--- a/components/BrandCard.tsx
+++ b/components/BrandCard.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useState } from 'react'
+import { type CSSProperties, useState } from 'react'
 
 import { brandSlug } from '../lib/utils/brandNormalizer'
 
@@ -28,10 +27,9 @@ export default function BrandCard({ name, count, sampleFlavors, imageUrl, index 
   const initials = getBrandInitials(name)
 
   return (
-    <motion.article
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ delay: Math.min(index * 0.015, 0.3), duration: 0.25 }}
+    <article
+      className="animate-card-in"
+      style={{ '--card-delay': `${Math.min(index * 15, 300)}ms` } as CSSProperties}
     >
       <Link
         href={`/brands/${brandSlug(name)}`}
@@ -77,6 +75,6 @@ export default function BrandCard({ name, count, sampleFlavors, imageUrl, index 
           )}
         </div>
       </Link>
-    </motion.article>
+    </article>
   )
 }

--- a/components/NoImage.tsx
+++ b/components/NoImage.tsx
@@ -2,9 +2,10 @@ import Image from 'next/image'
 
 interface NoImageProps {
   label?: string
+  priority?: boolean
 }
 
-export default function NoImage({ label = 'No image on file' }: NoImageProps) {
+export default function NoImage({ label = 'No image on file', priority = false }: NoImageProps) {
   return (
     <div className="absolute inset-0 bg-paper-100 dark:bg-paper-900 flex flex-col items-center justify-center">
       <div className="relative w-[68%] h-[72%] opacity-55 dark:opacity-45">
@@ -12,6 +13,7 @@ export default function NoImage({ label = 'No image on file' }: NoImageProps) {
           src="/images/no-image-shisha.png"
           alt=""
           fill
+          priority={priority}
           className="object-contain dark:invert"
           sizes="(max-width: 640px) 40vw, (max-width: 1024px) 20vw, 15vw"
         />

--- a/components/ShishaCard.tsx
+++ b/components/ShishaCard.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { motion } from 'framer-motion'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { MouseEvent } from 'react'
+import { type CSSProperties, MouseEvent } from 'react'
 
 import { brandSlug } from '../lib/utils/brandNormalizer'
 import type { ShishaFlavor } from '../types/shisha'
@@ -36,11 +35,9 @@ export default function ShishaCard({ flavor, onManufacturerClick, index = 0 }: S
   }
 
   return (
-    <motion.article
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ delay: Math.min(index * 0.02, 0.3), duration: 0.25 }}
-      className="group"
+    <article
+      className="group animate-card-in"
+      style={{ '--card-delay': `${Math.min(index * 20, 300)}ms` } as CSSProperties}
     >
       <Link
         href={`/flavor/${flavor.id}`}
@@ -95,6 +92,6 @@ export default function ShishaCard({ flavor, onManufacturerClick, index = 0 }: S
           </div>
         </div>
       </Link>
-    </motion.article>
+    </article>
   )
 }

--- a/components/home/HeroFallback.tsx
+++ b/components/home/HeroFallback.tsx
@@ -1,0 +1,96 @@
+import Link from 'next/link'
+
+interface HeroFallbackProps {
+  initialTotalItems: number
+  initialBrandsCount: number
+  lastDataUpdated: string | null
+}
+
+/**
+ * Server-rendered Suspense fallback for the home page.
+ * Puts the LCP element (<p> description) in the initial HTML so it is
+ * visible before JavaScript loads, improving LCP.
+ */
+export default function HeroFallback({ initialTotalItems, initialBrandsCount, lastDataUpdated }: HeroFallbackProps) {
+  return (
+    <div className="min-h-screen bg-paper-0 dark:bg-paper-950 text-ink-950 dark:text-ink-50">
+      <main className="mx-auto px-4 sm:px-6 lg:px-10 pt-8 sm:pt-10 pb-24 max-w-[1480px]">
+        <header className="flex flex-wrap items-center justify-between gap-3 py-3 border-t-2 border-b border-ink-900 dark:border-ink-100 font-mono-tight text-[10px] uppercase tracking-[0.16em] text-ink-700 dark:text-ink-200 mb-0">
+          <span className="flex items-center gap-3">
+            <span className="inline-block w-2 h-2 bg-ember-500" aria-hidden />
+            <span className="font-sans-tight font-semibold text-sm normal-case tracking-[-0.01em] text-ink-950 dark:text-ink-50">
+              Shisha Flavor Ledger
+            </span>
+            <span className="hidden sm:inline text-ink-400 dark:text-ink-500">—</span>
+            <span className="hidden sm:inline nums">Vol.&nbsp;I · Ed.&nbsp;2026</span>
+          </span>
+          <Link href="/brands" className="hover:text-ember-500 transition-colors">
+            Brand Index →
+          </Link>
+        </header>
+
+        <section className="grid grid-cols-12 gap-0 border-b border-ink-900 dark:border-ink-100">
+          <div className="col-span-12 lg:col-span-8 lg:border-r lg:border-rule-200 lg:dark:border-rule-800 py-10 lg:py-14 lg:pr-10">
+            <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ember-500 mb-5">
+              § 001 · The Ledger
+            </p>
+            <h1 className="font-sans-tight font-semibold leading-[0.9] tracking-[-0.04em] text-ink-950 dark:text-ink-50">
+              <span className="block text-[3.5rem] sm:text-[5rem] lg:text-[7rem]">
+                Shisha Flavor
+              </span>
+              <span className="block text-[3.5rem] sm:text-[5rem] lg:text-[7rem]">
+                Ledger<span className="text-ember-500">.</span>
+              </span>
+            </h1>
+            <p className="mt-8 font-sans-tight text-ink-600 dark:text-ink-300 text-base sm:text-lg leading-[1.5] max-w-[52ch]">
+              A verified record of every shisha flavor on sale in Japan, cross-checked against the Ministry of Finance tobacco ledger. Search by brand, flavor, or country; every entry lists grammage, origin, and current retail price.
+            </p>
+            <div className="mt-8 flex items-center gap-4">
+              <Link
+                href="/brands"
+                className="font-mono-tight text-[11px] uppercase tracking-[0.14em] px-4 py-2 bg-ink-900 text-paper-0 dark:bg-ink-100 dark:text-paper-950 hover:bg-ember-500 hover:text-paper-0 dark:hover:bg-ember-500 transition-colors"
+              >
+                Browse brand index →
+              </Link>
+              <span className="font-mono-tight text-[10px] uppercase tracking-[0.14em] text-ink-400 dark:text-ink-500">
+                or search below
+              </span>
+            </div>
+          </div>
+
+          <aside className="col-span-12 lg:col-span-4 grid grid-cols-2 lg:grid-cols-1 divide-x lg:divide-x-0 lg:divide-y divide-rule-200 dark:divide-rule-800 border-t lg:border-t-0 border-rule-200 dark:border-rule-800">
+            <div className="py-6 lg:py-7 px-5 lg:px-10">
+              <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ink-400 dark:text-ink-500 mb-2">
+                Indexed entries
+              </p>
+              <p className="font-sans-tight font-semibold text-4xl sm:text-5xl lg:text-6xl tracking-[-0.04em] text-ink-950 dark:text-ink-50 nums leading-none">
+                {initialTotalItems.toLocaleString()}
+              </p>
+            </div>
+            <Link
+              href="/brands"
+              className="py-6 lg:py-7 px-5 lg:px-10 block group hover:bg-paper-100 dark:hover:bg-paper-900 transition-colors"
+            >
+              <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ink-400 dark:text-ink-500 mb-2 group-hover:text-ember-500 transition-colors">
+                Brands →
+              </p>
+              <p className="font-sans-tight font-semibold text-4xl sm:text-5xl lg:text-6xl tracking-[-0.04em] text-ink-950 dark:text-ink-50 nums leading-none">
+                {initialBrandsCount}
+              </p>
+            </Link>
+            {lastDataUpdated && (
+              <div className="col-span-2 lg:col-span-1 py-6 lg:py-7 px-5 lg:px-10 border-t lg:border-t border-rule-200 dark:border-rule-800">
+                <p className="font-mono-tight text-[10px] uppercase tracking-[0.2em] text-ink-400 dark:text-ink-500 mb-2">
+                  Last refresh
+                </p>
+                <p className="font-mono-tight text-base text-ink-950 dark:text-ink-50 nums">
+                  {lastDataUpdated}
+                </p>
+              </div>
+            )}
+          </aside>
+        </section>
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Lighthouse 監査結果 (Before / After)

> 計測環境: `npx lighthouse http://localhost:3000` (開発サーバー、モバイル相当)

### 全ページ概要

| ページ | Perf Before | Perf After | 変化 | LCP Before | LCP After | 判定 |
|---|---|---|---|---|---|---|
| `/` (top) | 61 | **84** | +23 | 7.1 s | **1.8 s** | ✅ Good |
| `/brands` | 66 | **95** | +29 | 8.2 s | **2.0 s** | ✅ Good |
| `/brands/[slug]` | 63 | **89** | +26 | 8.4 s | **2.5 s** | 🟡 Needs Imp* |
| `/flavor/[id]` | 65 | **97** | +32 | 6.9 s | **2.0 s** | ✅ Good |

> \* `/brands/[slug]` の LCP 2.5s は開発サーバー特有の遅延 (ロゴ画像の最適化処理) が残るため。本番ビルドでは Good 域に入る見込み。

### `/` トップページ詳細

| メトリクス | Before | After |
|---|---|---|
| Performance | 61 | **84** |
| LCP | 7.1 s | **1.8 s** |
| FCP | 1.0 s | 0.9 s |
| TBT | 600 ms | 690 ms ※ |
| CLS | 0 | 0 |
| Speed Index | 2.7 s | **2.2 s** |
| Best Practices | 96 | **100** |
| Favicon 404 エラー | あり | なし |

> ※ TBT は開発サーバー固有のオーバーヘッド（未 minify JS・React DevTools）が主因。

---

## 根本原因と修正内容

### LCP が高かった共通原因

全ページで `motion.section` / `motion.article` に `initial={{ opacity: 0 }}` が付いており、Framer Motion がサーバーレンダリング時に LCP 要素を `style="opacity: 0"` でレンダリングしていた。ブラウザは要素が不可視の間は LCP タイマーを進めないため、JavaScript がロード・実行されるまで LCP が計上されなかった（Render Delay が LCP の 90% 以上）。

### 1. `components/home/HeroFallback.tsx` (新規) — `/` LCP 7.1s → 1.8s の主因

トップページの `ClientHome` は `useSearchParams()` のため `Suspense` で囲まれており、fallback がローディングスピナーだった。これにより LCP 要素（ヒーローの `<p>` 説明文）が初期 HTML に含まれず、JS ロード完了まで不可視だった。

Suspense fallback をヒーロー静的コンテンツに差し替えることで、初期 HTML に LCP 段落を含め、JS ロード前から表示されるようにした。

### 2. `app/page.tsx`

サーバー側で `getManufacturers()` と `shishaData.length` を取得し `initialManufacturers` / `initialTotalItems` として渡す。「Indexed entries」「Brands」カウンターの 0→N ちらつきを解消し、`/api/manufacturers` の初回フェッチを省略。

### 3. ヒーロー `motion.section` → `<section>` (4 ファイル)

`ClientHome.tsx` / `BrandsClient.tsx` / `BrandDetailClient.tsx` のヒーロー、`FlavorDetailClient.tsx` のメインコンテンツから `initial={{ opacity: 0 }}` アニメーションを除去。

### 4. `components/ShishaCard.tsx` / `BrandCard.tsx`

`motion.article` の staggered アニメーションを CSS `@keyframes card-fade-in` + `--card-delay` カスタムプロパティに置き換え。Framer Motion の JS 実行コストをカード枚数分削減。

### 5. `BrandDetailClient.tsx` — `/brands/[slug]` LCP 8.4s → 2.5s

ブランドロゴ `<Image>` に `priority` を追加。`priority` がなかったためロゴがレイジーロードされ、Load Delay が 1.7s 発生していた。

### 6. `components/NoImage.tsx` — `/flavor/[id]` LCP 6.9s → 2.0s

`priority` prop を追加。フレーバー詳細ページで画像なしのエントリは NoImage プレースホルダーが LCP 要素になるが、`priority` がなくレイジーロードで Load Delay が 4s 超発生していた。`FlavorDetailClient` から `priority` を渡すように変更。

### 7. `app/icon.svg`

ember カラー (#e8492c) の SVG favicon を追加。コンソール 404 エラーを解消し Best Practices を 96 → 100 に改善。

---

## Test plan

- [x] `pnpm typecheck` → エラーなし
- [x] `pnpm lint` → エラーなし（既存 warning のみ）
- [x] `pnpm test` → 37 tests passed
- [x] Lighthouse 再計測で全ページ Performance 改善・LCP 大幅短縮を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)