### PR TITLE
feat: OGP・Twitter Card・JSON-LD 構造化データ追加

### DIFF
--- a/app/brands/[slug]/page.tsx
+++ b/app/brands/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { brandSlug, getBrandImageUrl } from '../../../data/brandImages'
 import { resolveFlavorImage } from '../../../data/flavorImages'
 import { shishaData } from '../../../data/shishaData'
 import { normalizeBrandName } from '../../../lib/utils/brandNormalizer'
+import { escapeJsonLd } from '../../../lib/utils/jsonLd'
 import type { ShishaFlavor } from '../../../types/shisha'
 
 import BrandDetailClient from './BrandDetailClient'
@@ -71,14 +72,14 @@ export default async function BrandDetailPage({ params }: PageProps) {
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Brand',
-    name: brand.displayName ?? '',
+    name: brand.displayName,
   }
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(jsonLd) }}
       />
       <BrandDetailClient
         slug={slug.toLowerCase()}

--- a/app/brands/[slug]/page.tsx
+++ b/app/brands/[slug]/page.tsx
@@ -50,9 +50,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!brand) {
     return { title: 'Brand not found | Shisha Flavor Ledger' }
   }
+  const title = `${brand.displayName} — ${brand.flavors.length} flavors | Shisha Flavor Ledger`
+  const description = `All ${brand.flavors.length} shisha flavors produced by ${brand.displayName}, indexed in the Shisha Flavor Ledger.`
   return {
-    title: `${brand.displayName} — ${brand.flavors.length} flavors | Shisha Flavor Ledger`,
-    description: `All ${brand.flavors.length} shisha flavors produced by ${brand.displayName}, indexed in the Shisha Flavor Ledger.`,
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+    },
   }
 }
 
@@ -61,13 +68,25 @@ export default async function BrandDetailPage({ params }: PageProps) {
   const brand = resolveBrand(slug)
   if (!brand) notFound()
 
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Brand',
+    name: brand.displayName ?? '',
+  }
+
   return (
-    <BrandDetailClient
-      slug={slug.toLowerCase()}
-      brandName={brand.displayName}
-      flavors={brand.flavors}
-      imageUrl={brand.imageUrl}
-      description={getBrandDescription(slug)}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <BrandDetailClient
+        slug={slug.toLowerCase()}
+        brandName={brand.displayName}
+        flavors={brand.flavors}
+        imageUrl={brand.imageUrl}
+        description={getBrandDescription(slug)}
+      />
+    </>
   )
 }

--- a/app/flavor/[id]/page.tsx
+++ b/app/flavor/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { resolveFlavorImage } from '../../../data/flavorImages'
 import { shishaData } from '../../../data/shishaData'
 import { normalizeBrandForSearch } from '../../../lib/utils/brandNormalizer'
+import { escapeJsonLd } from '../../../lib/utils/jsonLd'
 import type { ShishaFlavor } from '../../../types/shisha'
 
 import FlavorDetailClient from './FlavorDetailClient'
@@ -61,8 +62,8 @@ export default async function FlavorDetailPage({ params }: PageProps) {
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'Product',
-    name: flavor.productName ?? '',
-    brand: { '@type': 'Brand', name: flavor.manufacturer ?? '' },
+    name: flavor.productName,
+    brand: { '@type': 'Brand', name: flavor.manufacturer },
     description: flavor.description ?? '',
   }
 
@@ -70,7 +71,7 @@ export default async function FlavorDetailPage({ params }: PageProps) {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(jsonLd) }}
       />
       <FlavorDetailClient flavor={flavor} related={related} />
     </>

--- a/app/flavor/[id]/page.tsx
+++ b/app/flavor/[id]/page.tsx
@@ -39,9 +39,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!flavor) {
     return { title: 'Flavor not found | Shisha Flavor Ledger' }
   }
+  const title = `${flavor.productName} — ${flavor.manufacturer} | Shisha Flavor Ledger`
+  const description = `${flavor.manufacturer} / ${flavor.productName} · ${flavor.amount} · ${flavor.country} · ${flavor.price}`
   return {
-    title: `${flavor.productName} — ${flavor.manufacturer} | Shisha Flavor Ledger`,
-    description: `${flavor.manufacturer} / ${flavor.productName} · ${flavor.amount} · ${flavor.country} · ${flavor.price}`,
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+    },
   }
 }
 
@@ -50,5 +57,22 @@ export default async function FlavorDetailPage({ params }: PageProps) {
   const flavor = findFlavor(id)
   if (!flavor) notFound()
   const related = findRelatedFlavors(flavor, RELATED_COUNT)
-  return <FlavorDetailClient flavor={flavor} related={related} />
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: flavor.productName ?? '',
+    brand: { '@type': 'Brand', name: flavor.manufacturer ?? '' },
+    description: flavor.description ?? '',
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <FlavorDetailClient flavor={flavor} related={related} />
+    </>
+  )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,12 @@ const geistMono = Geist_Mono({
   display: 'swap',
 })
 
+const SITE_URL = (
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+).replace(/\/$/, '')
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: 'Shisha Flavor Ledger',
   description: 'A ledger of shisha flavors — brand, grammage, price, origin.',
   openGraph: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,6 +20,16 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: 'Shisha Flavor Ledger',
   description: 'A ledger of shisha flavors — brand, grammage, price, origin.',
+  openGraph: {
+    type: 'website',
+    locale: 'ja_JP',
+    siteName: 'シーシャフレーバー検索',
+    title: 'Shisha Flavor Ledger',
+    description: 'A ledger of shisha flavors — brand, grammage, price, origin.',
+  },
+  twitter: {
+    card: 'summary',
+  },
 }
 
 interface RootLayoutProps {

--- a/lib/utils/jsonLd.ts
+++ b/lib/utils/jsonLd.ts
@@ -1,0 +1,12 @@
+// JSON-LD を <script> に dangerouslySetInnerHTML で注入する際の XSS / パース崩壊対策。
+// `</script>` などのトークンと、JSON.stringify がエスケープしない U+2028 / U+2029
+// (JS のソース上で行終端と解釈される) をエスケープする。
+const LINE_SEPARATORS = new RegExp('[\\u2028\\u2029]', 'g')
+
+export function escapeJsonLd(json: unknown): string {
+  return JSON.stringify(json)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(LINE_SEPARATORS, (ch) => (ch.charCodeAt(0) === 0x2028 ? '\\u2028' : '\\u2029'))
+}


### PR DESCRIPTION
## Summary
- `app/layout.tsx` にサイト全体の OGP (`type: website`, `locale: ja_JP`, `siteName`) と Twitter Card (`summary`) を追加
- フレーバー詳細ページ (`/flavor/[id]`) に OGP メタデータと JSON-LD `Product` スキーマ (name, brand, description) を埋め込み
- ブランドページ (`/brands/[slug]`) に OGP メタデータと JSON-LD `Brand` スキーマを埋め込み

これにより SNS シェア時のリッチプレビューと Google 検索のリッチリザルト対象化が期待できます。

## Test plan
- [ ] `pnpm lint && pnpm test && pnpm typecheck` 全通過確認済み
- [ ] OGP デバッガー (developers.facebook.com/tools/debug 等) でメタデータが正しく読まれることを確認
- [ ] フレーバー詳細ページの HTML に `<script type="application/ld+json">` が含まれていることを確認
- [ ] Schema.org Validator (validator.schema.org) で構造化データがエラーなしで読まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)