### PR TITLE
feat: X (旧Twitter) シェアボタンと OG 画像メタデータ追加

### DIFF
--- a/app/brands/[slug]/BrandDetailClient.tsx
+++ b/app/brands/[slug]/BrandDetailClient.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
 
+import ShareOnX from '../../../components/ShareOnX'
 import ShishaCard from '../../../components/ShishaCard'
 import type { ShishaFlavor } from '../../../types/shisha'
 
@@ -80,13 +81,17 @@ export default function BrandDetailClient({ slug, brandName, flavors, imageUrl, 
                 </>
               )}
             </p>
-            <div className="mt-8 flex items-center gap-4">
+            <div className="mt-8 flex flex-wrap items-center gap-4">
               <Link
                 href="/brands"
                 className="font-mono-tight text-[11px] uppercase tracking-[0.14em] px-4 py-2 border border-rule-200 dark:border-rule-800 text-ink-600 dark:text-ink-300 hover:border-ember-500 hover:text-ember-500 transition-colors"
               >
                 ← All brands
               </Link>
+              <ShareOnX
+                text={`${brandName} — ${flavors.length} flavors`}
+                hashtags={['シーシャ', 'shisha']}
+              />
               <Link
                 href="/"
                 className="font-mono-tight text-[11px] uppercase tracking-[0.14em] text-ink-400 dark:text-ink-500 hover:text-ember-500 transition-colors"

--- a/app/brands/[slug]/page.tsx
+++ b/app/brands/[slug]/page.tsx
@@ -53,13 +53,26 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
   const title = `${brand.displayName} — ${brand.flavors.length} flavors | Shisha Flavor Ledger`
   const description = `All ${brand.flavors.length} shisha flavors produced by ${brand.displayName}, indexed in the Shisha Flavor Ledger.`
+  const path = `/brands/${slug.toLowerCase()}`
+  const images = brand.imageUrl
+    ? [{ url: brand.imageUrl, alt: `${brand.displayName} logo` }]
+    : undefined
   return {
     title,
     description,
+    alternates: { canonical: path },
     openGraph: {
       title,
       description,
       type: 'website',
+      url: path,
+      images,
+    },
+    twitter: {
+      card: brand.imageUrl ? 'summary_large_image' : 'summary',
+      title,
+      description,
+      images: brand.imageUrl ? [brand.imageUrl] : undefined,
     },
   }
 }

--- a/app/flavor/[id]/FlavorDetailClient.tsx
+++ b/app/flavor/[id]/FlavorDetailClient.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 
 import NoImage from '../../../components/NoImage'
+import ShareOnX from '../../../components/ShareOnX'
 import ShishaCard from '../../../components/ShishaCard'
 import { brandSlug } from '../../../lib/utils/brandNormalizer'
 import type { ShishaFlavor } from '../../../types/shisha'
@@ -106,6 +107,16 @@ export default function FlavorDetailClient({ flavor, related = [] }: FlavorDetai
                   </dd>
                 </div>
               </dl>
+
+              <div className="py-6 border-b border-rule-200 dark:border-rule-800">
+                <p className="font-mono-tight text-[10px] uppercase tracking-[0.18em] text-ink-400 dark:text-ink-500 mb-3">
+                  Share
+                </p>
+                <ShareOnX
+                  text={`${flavor.productName} — ${flavor.manufacturer}`}
+                  hashtags={['シーシャ', 'shisha']}
+                />
+              </div>
 
               <div className="pt-6 font-mono-tight text-[10px] uppercase tracking-[0.14em] text-ink-400 dark:text-ink-500 flex items-center justify-between nums">
                 <span>Entry № {formatIndex(flavor.id)}</span>

--- a/app/flavor/[id]/page.tsx
+++ b/app/flavor/[id]/page.tsx
@@ -42,13 +42,26 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
   const title = `${flavor.productName} — ${flavor.manufacturer} | Shisha Flavor Ledger`
   const description = `${flavor.manufacturer} / ${flavor.productName} · ${flavor.amount} · ${flavor.country} · ${flavor.price}`
+  const path = `/flavor/${flavor.id}`
+  const images = flavor.imageUrl
+    ? [{ url: flavor.imageUrl, alt: flavor.productName }]
+    : undefined
   return {
     title,
     description,
+    alternates: { canonical: path },
     openGraph: {
       title,
       description,
       type: 'website',
+      url: path,
+      images,
+    },
+    twitter: {
+      card: flavor.imageUrl ? 'summary_large_image' : 'summary',
+      title,
+      description,
+      images: flavor.imageUrl ? [flavor.imageUrl] : undefined,
     },
   }
 }

--- a/components/ShareOnX.tsx
+++ b/components/ShareOnX.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface ShareOnXProps {
+  text: string
+  hashtags?: string[]
+  className?: string
+}
+
+export default function ShareOnX({ text, hashtags = [], className = '' }: ShareOnXProps) {
+  const [intentUrl, setIntentUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    const params = new URLSearchParams({ text, url: window.location.href })
+    if (hashtags.length > 0) params.set('hashtags', hashtags.join(','))
+    setIntentUrl(`https://x.com/intent/post?${params.toString()}`)
+  }, [text, hashtags])
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!intentUrl) e.preventDefault()
+  }
+
+  return (
+    <a
+      href={intentUrl ?? '#'}
+      onClick={handleClick}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="X (旧Twitter) にシェア"
+      className={`inline-flex items-center gap-2 px-4 py-2 border border-ink-900 dark:border-ink-100 hover:bg-ember-500 hover:border-ember-500 hover:text-paper-0 dark:hover:text-paper-0 transition-colors font-mono-tight text-[10px] uppercase tracking-[0.18em] text-ink-900 dark:text-ink-100 ${className}`}
+    >
+      <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+      </svg>
+      <span>Share on X</span>
+    </a>
+  )
+}


### PR DESCRIPTION
## Summary
- `components/ShareOnX.tsx` を新規追加。X の `intent/post` URL を新タブで開く client component。`aria-label` / `rel=\"noopener noreferrer\"` を付与
- フレーバー詳細ページ・ブランドページの両方に Share ボタンを設置。ハッシュタグ `#シーシャ #shisha` 付きで投稿される
- 既存の `generateMetadata` を拡張: `og:image` (フレーバー画像 / ブランドロゴ)・`og:url`・`alternates.canonical`・`twitter.card` (画像ありなら `summary_large_image`)・`twitter.images` を追加。SNS シェア時のリッチプレビューが効くようになる

## Test plan
- [ ] \`pnpm lint && pnpm test && pnpm typecheck && pnpm build\` 全通過確認済み
- [ ] フレーバー詳細ページの Share ボタンを押すと X の投稿画面が開き、フレーバー名・ブランド名・URL・ハッシュタグがプリフィルされる
- [ ] ブランドページの Share ボタンも同様に動作
- [ ] フレーバー詳細ページのソースに \`<meta property=\"og:image\">\` と \`<meta name=\"twitter:card\" content=\"summary_large_image\">\` が出力される
- [ ] OGP デバッガー (developers.facebook.com/tools/debug) で og:image が読み込めることを確認
- [ ] X の Card Validator (cards-dev.twitter.com/validator) でカードが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)