### PR TITLE
fix(share): use Web Share API on iOS to avoid X app login loop

### DIFF
--- a/components/ShareOnX.tsx
+++ b/components/ShareOnX.tsx
@@ -10,14 +10,29 @@ interface ShareOnXProps {
 
 export default function ShareOnX({ text, hashtags = [], className = '' }: ShareOnXProps) {
   const [intentUrl, setIntentUrl] = useState<string | null>(null)
+  const [canNativeShare, setCanNativeShare] = useState(false)
 
   useEffect(() => {
     const params = new URLSearchParams({ text, url: window.location.href })
     if (hashtags.length > 0) params.set('hashtags', hashtags.join(','))
     setIntentUrl(`https://x.com/intent/post?${params.toString()}`)
+    setCanNativeShare(typeof navigator !== 'undefined' && typeof navigator.share === 'function')
   }, [text, hashtags])
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+  const handleClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
+    // On iOS Safari, tapping x.com/intent/post triggers a Universal Link to
+    // the X app, whose in-app browser has no Safari session and forces a
+    // re-login. Prefer the Web Share API so the user shares from their
+    // already-logged-in browser via the native share sheet.
+    if (canNativeShare) {
+      e.preventDefault()
+      try {
+        await navigator.share({ text, url: window.location.href })
+      } catch {
+        // user cancelled or share was aborted — no fallback needed
+      }
+      return
+    }
     if (!intentUrl) e.preventDefault()
   }
 
@@ -27,13 +42,13 @@ export default function ShareOnX({ text, hashtags = [], className = '' }: ShareO
       onClick={handleClick}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label="X (旧Twitter) にシェア"
+      aria-label={canNativeShare ? 'シェア' : 'X (旧Twitter) にシェア'}
       className={`inline-flex items-center gap-2 px-4 py-2 border border-ink-900 dark:border-ink-100 hover:bg-ember-500 hover:border-ember-500 hover:text-paper-0 dark:hover:text-paper-0 transition-colors font-mono-tight text-[10px] uppercase tracking-[0.18em] text-ink-900 dark:text-ink-100 ${className}`}
     >
       <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
       </svg>
-      <span>Share on X</span>
+      <span>{canNativeShare ? 'Share' : 'Share on X'}</span>
     </a>
   )
 }


### PR DESCRIPTION
## Summary

iPhone で「Share on X」ボタンを押しても効かない、または X アプリに遷移してもアプリ内ブラウザでログインを要求される問題を修正。

## Cause

`components/ShareOnX.tsx` は `https://x.com/intent/post?...` への直接リンクだった。iOS Safari ではこの URL が X アプリの Universal Link として解釈され、X アプリの WebView (アプリ内ブラウザ) で開かれる。WebView は Safari のセッション Cookie を共有しないため、ログイン済みでも未ログイン状態に見え、ポスト画面ではなくログイン画面が出ていた。

## Fix

`components/ShareOnX.tsx`:
- `navigator.share` が使える環境 (iOS Safari / 多くのモバイルブラウザ) では Web Share API でネイティブ共有シートを開く。これにより既にログイン済みのアプリ/ブラウザに共有が委譲され、ログインを要求されない。
- 未対応環境 (主にデスクトップ) では従来通り `x.com/intent/post` を新規タブで開く。
- 文言・aria-label もネイティブ共有時は「Share / シェア」、フォールバック時は「Share on X / X (旧Twitter) にシェア」に切り替え。

## Test plan

- [ ] iPhone Safari で `/flavor/[id]` を開き Share ボタンを押す → iOS の共有シートが出ることを確認
- [ ] 共有シートから X を選んでポスト画面が直接開けることを確認 (再ログインを要求されない)
- [ ] デスクトップ Chrome / Firefox で押下 → x.com/intent/post が新規タブで開くことを確認
- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス (37/37)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NneXqWteNbAs32r1kvuokh)_