### PR TITLE
fix(meta): default SITE_URL to production domain to repair og:image and sitemap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,11 @@ pnpm build:data    # Regenerate data/generated/searchIndex.json + brands.json.
 - `/api/flavor/[id]/route.ts`: Returns individual flavor details (TypeScript) — **currently unused** (`/flavor/[id]` reads `shishaData` directly)
 
 ### Deployment
+- **本番ドメイン**: `https://shisha-lento.com`
 - **インフラ**: Cloudflare Workers + Assets (`@opennextjs/cloudflare`)。`wrangler.jsonc` で設定。
 - `pnpm deploy` で本番デプロイ。`pnpm preview` でローカル Workers プレビュー。
 - `open-next.config.ts` で `staticAssetsIncrementalCache` を使用（SSG ページのインクリメンタルキャッシュ）。
+- **og:image / canonical / sitemap の base URL**: `app/layout.tsx` / `app/sitemap.ts` / `app/robots.ts` の `SITE_URL` で決定。`NEXT_PUBLIC_SITE_URL` が build-time にセットされていれば優先、未設定時は `https://shisha-lento.com` にフォールバック (env を忘れて localhost が production に混入するのを防ぐ保険)。
 
 ### Routing Strategy
 - `/brands/[slug]` is **SSG** via `generateStaticParams` + `dynamicParams = false` (~92 pages; trivial build cost).

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,8 +17,11 @@ const geistMono = Geist_Mono({
   display: 'swap',
 })
 
+// NEXT_PUBLIC_SITE_URL は build-time inline されるため、未設定のまま
+// deploy されると og:url / og:image が dev ホストに化ける。env が抜けても
+// 本番が壊れないよう、本番ドメインをフォールバックにする。
 const SITE_URL = (
-  process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://shisha-lento.com'
 ).replace(/\/$/, '')
 
 export const metadata: Metadata = {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next'
 
 const SITE_URL = (
-  process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://shisha-lento.com'
 ).replace(/\/$/, '')
 
 export default function robots(): MetadataRoute.Robots {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,10 +4,11 @@ import { shishaData } from '../data/shishaData'
 import { brandSlug } from '../lib/utils/brandNormalizer'
 import type { ShishaFlavor } from '../types/shisha'
 
-// 本番の公開 URL は NEXT_PUBLIC_SITE_URL で設定する想定。
-// 未設定時は dev ホストにフォールバック (サーチエンジンへの送信時は必ず本番値を入れる)。
+// 本番の公開 URL。NEXT_PUBLIC_SITE_URL は build-time inline されるため、
+// 未設定で deploy すると sitemap が dev ホスト指しになる。env が抜けても
+// 本番が壊れないよう本番ドメインをフォールバックにしている。
 const SITE_URL = (
-  process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://shisha-lento.com'
 ).replace(/\/$/, '')
 
 export default function sitemap(): MetadataRoute.Sitemap {


### PR DESCRIPTION
## Summary

production の `og:url` / `og:image` が `http://localhost:3000/...` を指していて、SNS のカードプレビューが壊れていた問題を修正。

```
<meta property="og:url" content="http://localhost:3000/flavor/5296">
<meta property="og:image" content="http://localhost:3000/images/flavors/5296.jpeg">
```

## Cause

- Next.js Metadata API は `openGraph.images.url` の相対パス (`/images/flavors/<id>.webp`) を `metadataBase` で解決する。
- `app/layout.tsx` の `metadataBase` は `process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'`。
- `NEXT_PUBLIC_SITE_URL` は **build-time inline** されるが、リポジトリ内に設定箇所が無い (`.env*` 無し / `wrangler.jsonc` の `vars` 無し / deploy workflow 無し)。Cloudflare Workers ビルド時に env が抜けていたため、フォールバックの localhost が production に混入していた。
- 同じ env を参照する `app/sitemap.ts` / `app/robots.ts` も sitemap が localhost を指していた。

## Fix

3 ファイルのフォールバックを `http://localhost:3000` から本番ドメイン `https://shisha-lento.com` に変更:
- `app/layout.tsx`
- `app/sitemap.ts`
- `app/robots.ts`

env を明示的にセットしていれば従来通りそちらが優先される。env を忘れて deploy しても本番メタデータが壊れないよう保険としてのフォールバック。

## Test plan

- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス (37/37)
- [ ] deploy 後 `curl https://shisha-lento.com/flavor/5296 | grep og:` で `og:url` / `og:image` が `https://shisha-lento.com/...` になっていることを確認
- [ ] [Twitter Card Validator](https://cards-dev.twitter.com/validator) で OG プレビューを確認 (Twitter は廃止だが Discord / Slack / LINE 等のクローラ確認でも可)

## Follow-up (別 PR 推奨)

`/`, `/brands`, `/search` 等のページにはそもそも og:image が無い。`public/` に default OG 画像 (例: `og-default.png`) を用意して `app/layout.tsx` の `openGraph` に `images` を追加すると、フレーバー詳細以外でも画像付きカードになる。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NneXqWteNbAs32r1kvuokh)_