### PR TITLE
feat(seo): 日本語ユーザー向け SEO 強化

### DIFF
--- a/app/ClientHome.tsx
+++ b/app/ClientHome.tsx
@@ -197,6 +197,9 @@ function HomeContent({ editorialSections, lastDataUpdated, initialManufacturers 
             <p className="mt-8 font-sans-tight text-ink-600 dark:text-ink-300 text-base sm:text-lg leading-[1.5] max-w-[52ch]">
               A verified record of every shisha flavor on sale in Japan, cross-checked against the Ministry of Finance tobacco ledger. Search by brand, flavor, or country; every entry lists grammage, origin, and current retail price.
             </p>
+            <p className="mt-4 font-sans-tight text-ink-500 dark:text-ink-400 text-sm sm:text-base leading-[1.6] max-w-[52ch]">
+              日本国内で流通しているシーシャ(水たばこ)フレーバーを、ブランド名・フレーバー名・原産国から横断検索できる無料データベースです。AlFakher・STARBUZZ・Adalya・Fumari など主要銘柄の内容量・小売定価・産地を、財務省「製造たばこ小売定価」公告に基づいて随時更新しています。
+            </p>
             <div className="mt-8 flex items-center gap-4">
               <Link
                 href="/brands"

--- a/app/brands/[slug]/BrandDetailClient.tsx
+++ b/app/brands/[slug]/BrandDetailClient.tsx
@@ -106,7 +106,7 @@ export default function BrandDetailClient({ slug, brandName, flavors, imageUrl, 
               {showImage ? (
                 <Image
                   src={imageUrl as string}
-                  alt={`${brandName} logo`}
+                  alt={`${brandName} シーシャ ブランドロゴ`}
                   fill
                   priority
                   className="object-contain p-8 sm:p-10"

--- a/app/brands/[slug]/page.tsx
+++ b/app/brands/[slug]/page.tsx
@@ -49,13 +49,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { slug } = await params
   const brand = resolveBrand(slug)
   if (!brand) {
-    return { title: 'Brand not found | Shisha Flavor Ledger' }
+    return { title: 'ブランドが見つかりませんでした' }
   }
-  const title = `${brand.displayName} — ${brand.flavors.length} flavors | Shisha Flavor Ledger`
-  const description = `All ${brand.flavors.length} shisha flavors produced by ${brand.displayName}, indexed in the Shisha Flavor Ledger.`
+  const blurb = getBrandDescription(slug)
+  const title = `${brand.displayName} シーシャ フレーバー一覧 — 全${brand.flavors.length}種類`
+  const description = blurb
+    ? `${brand.displayName} のシーシャフレーバー全${brand.flavors.length}種類を一覧表示。${blurb} 内容量・原産国・小売定価まで日本の流通情報を網羅。`
+    : `${brand.displayName} のシーシャ(水たばこ)フレーバー全${brand.flavors.length}種類を一覧表示。内容量・原産国・小売定価まで、日本国内の流通情報を網羅した一覧ページ。`
   const path = `/brands/${slug.toLowerCase()}`
   const images = brand.imageUrl
-    ? [{ url: brand.imageUrl, alt: `${brand.displayName} logo` }]
+    ? [{ url: brand.imageUrl, alt: `${brand.displayName} シーシャ ブランドロゴ` }]
     : undefined
   return {
     title,
@@ -82,24 +85,64 @@ export default async function BrandDetailPage({ params }: PageProps) {
   const brand = resolveBrand(slug)
   if (!brand) notFound()
 
-  const jsonLd = {
+  const brandDescription = getBrandDescription(slug)
+  const brandJsonLd: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'Brand',
     name: brand.displayName,
+    url: `/brands/${slug.toLowerCase()}`,
+  }
+  if (brand.imageUrl) brandJsonLd.logo = brand.imageUrl
+  if (brandDescription) brandJsonLd.description = brandDescription
+
+  const itemListJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `${brand.displayName} シーシャ フレーバー一覧`,
+    numberOfItems: brand.flavors.length,
+    itemListElement: brand.flavors.slice(0, 50).map((f, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      url: `/flavor/${f.id}`,
+      name: f.productName,
+    })),
+  }
+
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'ホーム', item: '/' },
+      { '@type': 'ListItem', position: 2, name: 'ブランド一覧', item: '/brands' },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: brand.displayName,
+        item: `/brands/${slug.toLowerCase()}`,
+      },
+    ],
   }
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: escapeJsonLd(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(brandJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(itemListJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(breadcrumbJsonLd) }}
       />
       <BrandDetailClient
         slug={slug.toLowerCase()}
         brandName={brand.displayName}
         flavors={brand.flavors}
         imageUrl={brand.imageUrl}
-        description={getBrandDescription(slug)}
+        description={brandDescription}
       />
     </>
   )

--- a/app/brands/page.tsx
+++ b/app/brands/page.tsx
@@ -2,14 +2,23 @@ import type { Metadata } from 'next'
 
 import { getBrandImageUrl } from '../../data/brandImages'
 import { shishaData } from '../../data/shishaData'
-import { getUniqueBrands, normalizeBrandForSearch, normalizeBrandName } from '../../lib/utils/brandNormalizer'
+import { brandSlug, getUniqueBrands, normalizeBrandForSearch, normalizeBrandName } from '../../lib/utils/brandNormalizer'
+import { escapeJsonLd } from '../../lib/utils/jsonLd'
 import type { BrandSummary } from '../api/brands/route'
 
 import BrandsClient from './BrandsClient'
 
 export const metadata: Metadata = {
-  title: 'Brand Directory | Shisha Flavor Search',
-  description: '取り扱いシーシャブランドの一覧。ブランドから好みのフレーバーを探しましょう。',
+  title: 'シーシャ ブランド一覧 — 全銘柄ディレクトリ',
+  description:
+    '日本国内で流通しているシーシャ(水たばこ)フレーバーの全ブランド一覧。AlFakher / STARBUZZ / Adalya / Fumari / NAKHLA など主要メーカーから、各ブランドの取扱フレーバー数と代表的な商品名まで一覧で確認できます。',
+  alternates: { canonical: '/brands' },
+  openGraph: {
+    title: 'シーシャ ブランド一覧 — 全銘柄ディレクトリ',
+    description:
+      '日本で買えるシーシャブランド(AlFakher・STARBUZZ・Adalya 他)を網羅したディレクトリ。',
+    url: '/brands',
+  },
 }
 
 function buildBrandSummaries(): BrandSummary[] {
@@ -45,5 +54,40 @@ function buildBrandSummaries(): BrandSummary[] {
 
 export default function BrandsPage() {
   const brands = buildBrandSummaries()
-  return <BrandsClient brands={brands} />
+
+  const itemListJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'シーシャ ブランド一覧',
+    numberOfItems: brands.length,
+    itemListElement: brands.slice(0, 50).map((b, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      url: `/brands/${brandSlug(b.name)}`,
+      name: b.name,
+    })),
+  }
+
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'ホーム', item: '/' },
+      { '@type': 'ListItem', position: 2, name: 'ブランド一覧', item: '/brands' },
+    ],
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(itemListJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(breadcrumbJsonLd) }}
+      />
+      <BrandsClient brands={brands} />
+    </>
+  )
 }

--- a/app/flavor/[id]/FlavorDetailClient.tsx
+++ b/app/flavor/[id]/FlavorDetailClient.tsx
@@ -40,7 +40,7 @@ export default function FlavorDetailClient({ flavor, related = [] }: FlavorDetai
               {flavor.imageUrl ? (
                 <Image
                   src={flavor.imageUrl.replace('.png', '_w.png')}
-                  alt={flavor.productName}
+                  alt={`${flavor.manufacturer} ${flavor.productName} シーシャ フレーバー`}
                   fill
                   className="object-cover"
                   sizes="(max-width: 768px) 100vw, 58vw"

--- a/app/flavor/[id]/page.tsx
+++ b/app/flavor/[id]/page.tsx
@@ -3,8 +3,9 @@ import { notFound } from 'next/navigation'
 
 import { resolveFlavorImage } from '../../../data/flavorImages'
 import { shishaData } from '../../../data/shishaData'
-import { normalizeBrandForSearch } from '../../../lib/utils/brandNormalizer'
+import { brandSlug, normalizeBrandForSearch } from '../../../lib/utils/brandNormalizer'
 import { escapeJsonLd } from '../../../lib/utils/jsonLd'
+import { parseJpyPrice } from '../../../lib/utils/priceParser'
 import type { ShishaFlavor } from '../../../types/shisha'
 
 import FlavorDetailClient from './FlavorDetailClient'
@@ -38,13 +39,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { id } = await params
   const flavor = findFlavor(id)
   if (!flavor) {
-    return { title: 'Flavor not found | Shisha Flavor Ledger' }
+    return { title: 'フレーバーが見つかりませんでした' }
   }
-  const title = `${flavor.productName} — ${flavor.manufacturer} | Shisha Flavor Ledger`
-  const description = `${flavor.manufacturer} / ${flavor.productName} · ${flavor.amount} · ${flavor.country} · ${flavor.price}`
+  const title = `${flavor.productName}(${flavor.manufacturer}) シーシャ フレーバー — ${flavor.price} / ${flavor.amount}`
+  const description = `${flavor.manufacturer}「${flavor.productName}」のシーシャ用フレーバー情報。内容量 ${flavor.amount}、原産国 ${flavor.country}、小売定価 ${flavor.price}。${flavor.description ? `テイスティングノート: ${flavor.description}` : '日本国内の流通情報を財務省「製造たばこ小売定価」公告に基づいて掲載しています。'}`
   const path = `/flavor/${flavor.id}`
   const images = flavor.imageUrl
-    ? [{ url: flavor.imageUrl, alt: flavor.productName }]
+    ? [{ url: flavor.imageUrl, alt: `${flavor.manufacturer} ${flavor.productName} シーシャ フレーバー` }]
     : undefined
   return {
     title,
@@ -72,19 +73,60 @@ export default async function FlavorDetailPage({ params }: PageProps) {
   if (!flavor) notFound()
   const related = findRelatedFlavors(flavor, RELATED_COUNT)
 
-  const jsonLd = {
+  const price = parseJpyPrice(flavor.price)
+  const productJsonLd: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'Product',
-    name: flavor.productName,
+    name: `${flavor.productName} (${flavor.manufacturer})`,
     brand: { '@type': 'Brand', name: flavor.manufacturer },
-    description: flavor.description ?? '',
+    category: 'シーシャ フレーバー / 水たばこ',
+    countryOfOrigin: flavor.country,
+    description:
+      flavor.description ??
+      `${flavor.manufacturer}「${flavor.productName}」のシーシャ用フレーバー。内容量 ${flavor.amount}、原産国 ${flavor.country}、小売定価 ${flavor.price}。`,
+  }
+  if (flavor.imageUrl) {
+    productJsonLd.image = flavor.imageUrl
+  }
+  if (price !== null) {
+    productJsonLd.offers = {
+      '@type': 'Offer',
+      price,
+      priceCurrency: 'JPY',
+      availability: 'https://schema.org/InStock',
+      areaServed: 'JP',
+    }
+  }
+
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'ホーム', item: '/' },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: flavor.manufacturer,
+        item: `/brands/${brandSlug(flavor.manufacturer)}`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: flavor.productName,
+        item: `/flavor/${flavor.id}`,
+      },
+    ],
   }
 
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: escapeJsonLd(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(productJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonLd(breadcrumbJsonLd) }}
       />
       <FlavorDetailClient flavor={flavor} related={related} />
     </>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono } from 'next/font/google'
 
 import { ThemeProvider } from '../components/ThemeProvider'
 import { ThemeToggle } from '../components/ThemeToggle'
+import { escapeJsonLd } from '../lib/utils/jsonLd'
 
 const geistSans = Geist({
   subsets: ['latin'],
@@ -24,20 +25,70 @@ const SITE_URL = (
   process.env.NEXT_PUBLIC_SITE_URL ?? 'https://shisha-lento.com'
 ).replace(/\/$/, '')
 
+const SITE_NAME = 'シーシャフレーバー検索 — Shisha Flavor Ledger'
+const SITE_TITLE = 'シーシャフレーバー検索 | 全銘柄の価格・内容量・原産国を横断検索'
+const SITE_DESCRIPTION =
+  '日本で流通しているシーシャ(水たばこ)フレーバーを横断検索できる無料データベース。AlFakher / STARBUZZ / Adalya / Fumari など主要ブランドの商品名・内容量・原産国・小売定価を網羅し、財務省「製造たばこ小売定価」公告に基づいて随時更新しています。'
+
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
-  title: 'Shisha Flavor Ledger',
-  description: 'A ledger of shisha flavors — brand, grammage, price, origin.',
+  title: {
+    default: SITE_TITLE,
+    template: '%s | シーシャフレーバー検索',
+  },
+  description: SITE_DESCRIPTION,
+  alternates: { canonical: '/' },
+  keywords: [
+    'シーシャ',
+    'フレーバー',
+    '水たばこ',
+    'シーシャ 銘柄',
+    'シーシャ フレーバー 一覧',
+    'シーシャ 値段',
+    'AlFakher',
+    'STARBUZZ',
+    'Adalya',
+    'Fumari',
+  ],
   openGraph: {
     type: 'website',
     locale: 'ja_JP',
-    siteName: 'シーシャフレーバー検索',
-    title: 'Shisha Flavor Ledger',
-    description: 'A ledger of shisha flavors — brand, grammage, price, origin.',
+    siteName: SITE_NAME,
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    url: '/',
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
   },
+}
+
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: SITE_NAME,
+  alternateName: 'シーシャフレーバー検索',
+  url: `${SITE_URL}/`,
+  inLanguage: 'ja',
+  description: SITE_DESCRIPTION,
+  potentialAction: {
+    '@type': 'SearchAction',
+    target: {
+      '@type': 'EntryPoint',
+      urlTemplate: `${SITE_URL}/?q={search_term_string}`,
+    },
+    'query-input': 'required name=search_term_string',
+  },
+}
+
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: SITE_NAME,
+  url: `${SITE_URL}/`,
+  logo: `${SITE_URL}/icon.svg`,
 }
 
 interface RootLayoutProps {
@@ -55,6 +106,14 @@ export default function RootLayout({ children }: RootLayoutProps) {
         className="min-h-screen bg-paper-0 dark:bg-paper-950 text-ink-900 dark:text-ink-100 transition-colors duration-150 font-sans-tight"
         suppressHydrationWarning
       >
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: escapeJsonLd(websiteJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: escapeJsonLd(organizationJsonLd) }}
+        />
         <ThemeProvider>
           <ThemeToggle />
           {children}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,95 @@
+import { ImageResponse } from 'next/og'
+
+export const alt = 'シーシャフレーバー検索 — 日本国内で流通しているシーシャ フレーバーを横断検索'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          background: '#fafaf7',
+          color: '#0a0a0a',
+          padding: '64px 72px',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div
+            style={{
+              width: 14,
+              height: 14,
+              background: '#e8492c',
+            }}
+          />
+          <div
+            style={{
+              fontSize: 22,
+              letterSpacing: 6,
+              textTransform: 'uppercase',
+              color: '#525252',
+            }}
+          >
+            § Shisha Flavor Ledger
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+          <div
+            style={{
+              fontSize: 110,
+              fontWeight: 700,
+              lineHeight: 0.95,
+              letterSpacing: -4,
+            }}
+          >
+            シーシャフレーバー
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 110,
+              fontWeight: 700,
+              lineHeight: 0.95,
+              letterSpacing: -4,
+            }}
+          >
+            <span>検索</span>
+            <span style={{ color: '#e8492c' }}>.</span>
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-end',
+            borderTop: '1px solid #0a0a0a',
+            paddingTop: 20,
+          }}
+        >
+          <div style={{ fontSize: 26, color: '#404040', maxWidth: 760 }}>
+            日本国内で流通している水たばこフレーバーを、ブランド・原産国・価格で横断検索
+          </div>
+          <div
+            style={{
+              fontSize: 20,
+              letterSpacing: 3,
+              textTransform: 'uppercase',
+              color: '#737373',
+            }}
+          >
+            shisha-lento.com
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/components/BrandCard.tsx
+++ b/components/BrandCard.tsx
@@ -39,7 +39,7 @@ export default function BrandCard({ name, count, sampleFlavors, imageUrl, index 
           {showImage ? (
             <Image
               src={imageUrl as string}
-              alt={`${name} logo`}
+              alt={`${name} シーシャ ブランドロゴ`}
               fill
               className="object-contain p-6 transition-transform duration-300 ease-out group-hover:scale-[1.02]"
               sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 20vw"

--- a/components/ShishaCard.tsx
+++ b/components/ShishaCard.tsx
@@ -47,7 +47,7 @@ export default function ShishaCard({ flavor, onManufacturerClick, index = 0 }: S
           {flavor.imageUrl ? (
             <Image
               src={flavor.imageUrl}
-              alt={flavor.productName}
+              alt={`${flavor.manufacturer} ${flavor.productName} シーシャ フレーバー`}
               fill
               className="object-cover transition-transform duration-300 ease-out group-hover:scale-[1.015]"
               sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 20vw"

--- a/components/__tests__/ShishaCard.test.tsx
+++ b/components/__tests__/ShishaCard.test.tsx
@@ -21,7 +21,9 @@ describe('ShishaCard', () => {
     expect(screen.getByText(mockFlavor.productName)).toBeInTheDocument()
     expect(screen.getByText(mockFlavor.manufacturer)).toBeInTheDocument()
     expect(screen.getByText(mockFlavor.price)).toBeInTheDocument()
-    expect(screen.getByAltText(mockFlavor.productName)).toBeInTheDocument()
+    expect(
+      screen.getByAltText(`${mockFlavor.manufacturer} ${mockFlavor.productName} シーシャ フレーバー`)
+    ).toBeInTheDocument()
   })
 
   it('links to the correct flavor page', () => {

--- a/components/home/EditorsPicks.tsx
+++ b/components/home/EditorsPicks.tsx
@@ -42,7 +42,7 @@ export default function EditorsPicks({ picks }: EditorsPicksProps) {
                 {hasImg ? (
                   <Image
                     src={flavor.imageUrl}
-                    alt={flavor.productName}
+                    alt={`${flavor.manufacturer} ${flavor.productName} シーシャ フレーバー`}
                     fill
                     sizes="112px"
                     className="object-cover transition-transform duration-300 ease-out group-hover:scale-[1.02]"

--- a/components/home/FeaturedBrands.tsx
+++ b/components/home/FeaturedBrands.tsx
@@ -32,7 +32,7 @@ export default function FeaturedBrands({ brands }: FeaturedBrandsProps) {
               <div className="relative h-14 w-24 shrink-0 bg-paper-50 dark:bg-paper-900 border border-rule-200 dark:border-rule-800">
                 <Image
                   src={brand.imageUrl as string}
-                  alt={`${brand.name} logo`}
+                  alt={`${brand.name} シーシャ ブランドロゴ`}
                   fill
                   sizes="96px"
                   className="object-contain p-2"

--- a/components/home/HeroFallback.tsx
+++ b/components/home/HeroFallback.tsx
@@ -45,6 +45,9 @@ export default function HeroFallback({ initialTotalItems, initialBrandsCount, la
             <p className="mt-8 font-sans-tight text-ink-600 dark:text-ink-300 text-base sm:text-lg leading-[1.5] max-w-[52ch]">
               A verified record of every shisha flavor on sale in Japan, cross-checked against the Ministry of Finance tobacco ledger. Search by brand, flavor, or country; every entry lists grammage, origin, and current retail price.
             </p>
+            <p className="mt-4 font-sans-tight text-ink-500 dark:text-ink-400 text-sm sm:text-base leading-[1.6] max-w-[52ch]">
+              日本国内で流通しているシーシャ(水たばこ)フレーバーを、ブランド名・フレーバー名・原産国から横断検索できる無料データベースです。AlFakher・STARBUZZ・Adalya・Fumari など主要銘柄の内容量・小売定価・産地を、財務省「製造たばこ小売定価」公告に基づいて随時更新しています。
+            </p>
             <div className="mt-8 flex items-center gap-4">
               <Link
                 href="/brands"

--- a/lib/utils/priceParser.ts
+++ b/lib/utils/priceParser.ts
@@ -1,0 +1,10 @@
+// "14,000円" や "1,200円" のような表記から税込小売定価の数値 (JPY) を抜き出す。
+// JSON-LD Product offers の price フィールド用。
+export function parseJpyPrice(price: string | undefined | null): number | null {
+  if (!price) return null
+  const digits = price.replace(/[^\d]/g, '')
+  if (!digits) return null
+  const n = Number(digits)
+  if (!Number.isFinite(n) || n <= 0) return null
+  return n
+}


### PR DESCRIPTION
## Summary

日本のシーシャユーザーに刺さる検索クエリ ("シーシャ フレーバー", "シーシャ 銘柄", "{ブランド名} 値段" 等) で SERP に出やすくするための SEO 強化。Tier 1 + Tier 2。

### Tier 1 — meta / 構造化データ
- **ルート `metadata`** を日本語化 (title / description / keywords / OG / Twitter)。template も追加して子ページの title 表記を統一。
- **`WebSite` + `SearchAction` + `Organization` JSON-LD** を `app/layout.tsx` に追加。Google Sitelinks Searchbox の対象に。
- **`/flavor/[id]`**
  - title / description を日本語化 ("{商品名}({ブランド}) シーシャ フレーバー — {価格} / {内容量}")
  - Product JSON-LD に `offers` (priceCurrency: JPY) / `image` / `category` / `countryOfOrigin` を追加
  - `BreadcrumbList` を追加
- **`/brands`**
  - title / description を日本語化
  - `ItemList` (先頭 50 件) + `BreadcrumbList` JSON-LD を追加
- **`/brands/[slug]`**
  - title を「{ブランド名} シーシャ フレーバー一覧 — 全{N}種類」に
  - description は `brandDescriptions.ts` の日本語ブランド紹介を使って組み立て
  - Brand JSON-LD を `logo` / `description` で拡張、`ItemList` と `BreadcrumbList` を追加

### Tier 2 — 表示・OG・alt
- **デフォルト OG 画像** (`app/opengraph-image.tsx`) を ImageResponse で追加 (個別ページに OG 画像が無い場合のフォールバック)。Twitter card も `summary_large_image` に。
- **Home hero + HeroFallback** に日本語の補足本文を追加 (主要キーワードを自然文で散布)。既存の英語デザインは維持。
- **`<img alt>`** を全カード/詳細で「{ブランド} {商品名} シーシャ フレーバー」「{ブランド} シーシャ ブランドロゴ」形式に。画像検索からの流入対策。

### 補助
- `lib/utils/priceParser.ts`: "14,000円" → `14000` を抽出するヘルパ (Product offers.price 用)。

## 本 PR で扱わなかったもの (Tier 3)
- `sitemap.ts` の `lastModified` を flavor 単位の更新日に精緻化
- 内部リンク文言の日本語キーワード散布 (related flavors 等)

## Test plan

- [x] `pnpm lint` — 既存 warning のみ
- [x] `pnpm typecheck` — 通過
- [x] `pnpm test` — 37 passed
- [x] `pnpm build` — 通過 (`/opengraph-image` も静的生成)
- [ ] デプロイ後 https://search.google.com/test/rich-results で `Product` / `Breadcrumb` / `WebSite` / `ItemList` がパース成功するか確認
- [ ] `https://shisha-lento.com/opengraph-image` を Twitter Card Validator / Facebook Sharing Debugger で確認
- [ ] Google Search Console で sitemap の再送信 (URL 自体は変わっていないが title/description を反映させるため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)