### PR TITLE
fix(share): X シェアボタンが PC で動かない問題

### DIFF
--- a/components/ShareOnX.tsx
+++ b/components/ShareOnX.tsx
@@ -10,45 +10,28 @@ interface ShareOnXProps {
 
 export default function ShareOnX({ text, hashtags = [], className = '' }: ShareOnXProps) {
   const [intentUrl, setIntentUrl] = useState<string | null>(null)
-  const [canNativeShare, setCanNativeShare] = useState(false)
 
   useEffect(() => {
     const params = new URLSearchParams({ text, url: window.location.href })
     if (hashtags.length > 0) params.set('hashtags', hashtags.join(','))
     setIntentUrl(`https://x.com/intent/post?${params.toString()}`)
-    setCanNativeShare(typeof navigator !== 'undefined' && typeof navigator.share === 'function')
   }, [text, hashtags])
-
-  const handleClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
-    // On iOS Safari, tapping x.com/intent/post triggers a Universal Link to
-    // the X app, whose in-app browser has no Safari session and forces a
-    // re-login. Prefer the Web Share API so the user shares from their
-    // already-logged-in browser via the native share sheet.
-    if (canNativeShare) {
-      e.preventDefault()
-      try {
-        await navigator.share({ text, url: window.location.href })
-      } catch {
-        // user cancelled or share was aborted — no fallback needed
-      }
-      return
-    }
-    if (!intentUrl) e.preventDefault()
-  }
 
   return (
     <a
       href={intentUrl ?? '#'}
-      onClick={handleClick}
+      onClick={(e) => {
+        if (!intentUrl) e.preventDefault()
+      }}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label={canNativeShare ? 'シェア' : 'X (旧Twitter) にシェア'}
+      aria-label="X (旧Twitter) にシェア"
       className={`inline-flex items-center gap-2 px-4 py-2 border border-ink-900 dark:border-ink-100 hover:bg-ember-500 hover:border-ember-500 hover:text-paper-0 dark:hover:text-paper-0 transition-colors font-mono-tight text-[10px] uppercase tracking-[0.18em] text-ink-900 dark:text-ink-100 ${className}`}
     >
       <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
       </svg>
-      <span>{canNativeShare ? 'Share' : 'Share on X'}</span>
+      <span>Share on X</span>
     </a>
   )
 }


### PR DESCRIPTION
## Summary

- PC Chrome 等で `navigator.share` の存在判定が true になり、Web Share 経路に入って実質クリックが何も起きないように見える挙動を修正
- 全環境で素直に `https://x.com/intent/post?text=...&url=...&hashtags=...` を新規タブで開くシンプルなリンクに戻す

旧実装は iOS Safari の Universal Link 対策として Web Share API を優先していたが、PC 体験を犠牲にしていたため取り下げ。

## Test plan

- [x] pnpm lint
- [x] pnpm test (37 passed)
- [ ] PC Chrome / Firefox / Safari で flavor 詳細の Share on X をクリックし、x.com/intent/post に新規タブで遷移すること
- [ ] iOS Safari で同様に intent/post が開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)