### PR TITLE
perf(mobile): static asset を immutable キャッシュ + framer-motion 撤去

### DIFF
--- a/app/ClientHome.tsx
+++ b/app/ClientHome.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useState, useEffect, Suspense, type ReactNode } from 'react'
@@ -281,13 +280,12 @@ function HomeContent({ editorialSections, lastDataUpdated, initialManufacturers 
           </span>
         </div>
 
-        <AnimatePresence mode="wait">
-          {loading ? (
-            <motion.div key="loader" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="pt-6">
-              <SkeletonGrid count={12} />
-            </motion.div>
-          ) : (
-            <motion.div key="results" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="pt-6">
+        {loading ? (
+          <div key="loader" className="pt-6">
+            <SkeletonGrid count={12} />
+          </div>
+        ) : (
+          <div key="results" className="pt-6">
               {flavors.length > 0 ? (
                 <>
                   <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
@@ -356,9 +354,8 @@ function HomeContent({ editorialSections, lastDataUpdated, initialManufacturers 
                   </button>
                 </div>
               )}
-            </motion.div>
-          )}
-        </AnimatePresence>
+          </div>
+        )}
       </main>
     </div>
   )

--- a/components/BrandList.tsx
+++ b/components/BrandList.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { useState, useMemo, useEffect } from 'react'
 
@@ -94,17 +93,9 @@ export default function BrandList({ manufacturers, selectedManufacturer, onSelec
         )}
       </div>
 
-      <AnimatePresence>
-        {isExpanded && (
-          <motion.div
-            id="brand-list-full"
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: 'auto' }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.2 }}
-            className="overflow-hidden"
-          >
-            <div className="mt-5 border border-rule-200 dark:border-rule-800 bg-paper-0 dark:bg-paper-950">
+      {isExpanded && (
+        <div id="brand-list-full" className="overflow-hidden">
+          <div className="mt-5 border border-rule-200 dark:border-rule-800 bg-paper-0 dark:bg-paper-950">
               <div className="flex items-center gap-3 border-b border-rule-200 dark:border-rule-800 px-3 py-2.5">
                 <span className="font-mono-tight text-[10px] uppercase tracking-[0.18em] text-ink-500 dark:text-ink-400 shrink-0">
                   Q.
@@ -143,10 +134,9 @@ export default function BrandList({ manufacturers, selectedManufacturer, onSelec
                   no matches
                 </p>
               )}
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { motion, AnimatePresence } from 'framer-motion'
 import { useState, useEffect, FormEvent, useMemo } from 'react'
 
 import { debounce } from '../utils/debounce'
@@ -110,20 +109,15 @@ export default function SearchBar({ onSearch, searchQuery = '', isSearching = fa
                   searching
                 </span>
               )}
-              <AnimatePresence>
-                {searchTerm && (
-                  <motion.button
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    type="button"
-                    onClick={handleClear}
-                    className="font-mono-tight text-[10px] uppercase tracking-[0.14em] text-ink-500 dark:text-ink-400 hover:text-ember-500 transition-colors px-3 py-3"
-                  >
-                    clear ×
-                  </motion.button>
-                )}
-              </AnimatePresence>
+              {searchTerm && (
+                <button
+                  type="button"
+                  onClick={handleClear}
+                  className="font-mono-tight text-[10px] uppercase tracking-[0.14em] text-ink-500 dark:text-ink-400 hover:text-ember-500 transition-colors px-3 py-3"
+                >
+                  clear ×
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/components/home/OriginShelf.tsx
+++ b/components/home/OriginShelf.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { motion, AnimatePresence } from 'framer-motion'
 import { useState } from 'react'
 
 import ShishaCard from '../ShishaCard'
@@ -48,20 +47,14 @@ export default function OriginShelf({ buckets }: OriginShelfProps) {
         })}
       </div>
 
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={active.code}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.2 }}
-          className="pt-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4"
-        >
-          {active.flavors.map((flavor, idx) => (
-            <ShishaCard key={flavor.id} flavor={flavor} index={idx} />
-          ))}
-        </motion.div>
-      </AnimatePresence>
+      <div
+        key={active.code}
+        className="pt-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4"
+      >
+        {active.flavors.map((flavor, idx) => (
+          <ShishaCard key={flavor.id} flavor={flavor} index={idx} />
+        ))}
+      </div>
     </section>
   )
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "clsx": "^2.1.1",
-    "framer-motion": "^12.38.0",
     "fuse.js": "^7.3.0",
     "next": "^16.2.6",
     "react": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      framer-motion:
-        specifier: ^12.38.0
-        version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fuse.js:
         specifier: ^7.3.0
         version: 7.3.0
@@ -2985,20 +2982,6 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  framer-motion@12.38.0:
-    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -3811,12 +3794,6 @@ packages:
 
   mnemonist@0.38.3:
     resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
-
-  motion-dom@12.38.0:
-    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
-
-  motion-utils@12.36.0:
-    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -8337,15 +8314,6 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  framer-motion@12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      motion-dom: 12.38.0
-      motion-utils: 12.36.0
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
   fresh@2.0.0: {}
 
   fs.realpath@1.0.0: {}
@@ -9350,12 +9318,6 @@ snapshots:
   mnemonist@0.38.3:
     dependencies:
       obliterator: 1.6.1
-
-  motion-dom@12.38.0:
-    dependencies:
-      motion-utils: 12.36.0
-
-  motion-utils@12.36.0: {}
 
   ms@2.1.3: {}
 

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,21 @@
+# Next.js が出力する hashed asset は中身が変われば URL も変わるので
+# 永続キャッシュにする。Cloudflare Workers Assets のデフォルトは
+# `public, max-age=0, must-revalidate` で、リビジット時に CSS/JS が
+# 毎回 304 待ちになり LCP に悪影響を及ぼしていた。
+
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/_next/static/media/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# OG 画像 / アイコンも長期キャッシュでよい
+/opengraph-image
+  Cache-Control: public, max-age=86400, must-revalidate
+
+/icon.svg
+  Cache-Control: public, max-age=86400, must-revalidate
+
+# フレーバー / ブランド画像 (中身は固定運用)
+/images/*
+  Cache-Control: public, max-age=604800, must-revalidate


### PR DESCRIPTION
## Summary

PSI mobile Performance スコア **71** (LCP 5.0s, FCP 2.3s, TBT 280ms, SI 4.3s) の主犯 2 件を潰す。Core Web Vitals (LCP) と TBT 両方に効く想定。

### 1. \`public/_headers\` で static asset を immutable キャッシュ

Cloudflare Workers Assets のデフォルトが \`public, max-age=0, must-revalidate\` で、hashed asset (\`_next/static/chunks/0n1jdia0cev87.css\` 等) すらリビジット時に毎回 304 待ち。DevTools の Performance Insights で「Render-blocking requests」として CSS 1 本に 577ms 食われていた。

- \`/_next/static/*\` / \`/_next/static/media/*\` → \`max-age=31536000, immutable\`
- \`/images/*\` → 1 週間
- \`/opengraph-image\` / \`/icon.svg\` → 1 日

### 2. framer-motion を撤去

4 ファイルで使われていたが、いずれも \`opacity: 0 → 1\` の fade か簡単な height アニメだけ。CSS で代替可能、または見た目への影響が小さいので素直に除去:

- \`app/ClientHome.tsx\`: 検索結果切替の \`AnimatePresence\` 削除
- \`components/SearchBar.tsx\`: clear ボタン fade-in 削除
- \`components/BrandList.tsx\`: 全ブランド展開の opacity+height アニメ削除
- \`components/home/OriginShelf.tsx\`: 産地タブ切替の fade 削除

\`package.json\` から \`framer-motion\` 依存も削除。バンドル ~40KB gzip + hydration 時の評価コスト削減 (TBT 280ms → 改善見込み)。

## Test plan

- [x] pnpm lint / typecheck / test (37 passed) / build 全通過
- [ ] デプロイ後 PSI mobile を再測定 → Performance 90+ を狙う
- [ ] 主要ページ (home / brands / brand 詳細 / flavor 詳細) で見た目崩れがないか確認
- [ ] Cloudflare で \`Cache-Control\` レスポンスヘッダが意図通りか curl で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)