### PR TITLE
fix(share): シェア URL を x.com/intent/tweet に切替えて iPhone の再ログインを回避

### DIFF
--- a/components/ShareOnX.tsx
+++ b/components/ShareOnX.tsx
@@ -14,7 +14,11 @@ export default function ShareOnX({ text, hashtags = [], className = '' }: ShareO
   useEffect(() => {
     const params = new URLSearchParams({ text, url: window.location.href })
     if (hashtags.length > 0) params.set('hashtags', hashtags.join(','))
-    setIntentUrl(`https://x.com/intent/post?${params.toString()}`)
+    // x.com/intent/tweet を使う。x.com/intent/post は iOS で X アプリの
+    // Universal Link を発火し、アプリ内ブラウザに Safari セッションが無く
+    // 再ログインを強いられる。同じ x.com でも旧 /intent/tweet パスは
+    // Universal Link 対象外で Safari でそのまま開く。
+    setIntentUrl(`https://x.com/intent/tweet?${params.toString()}`)
   }, [text, hashtags])
 
   return (


### PR DESCRIPTION
## 背景

iPhone Safari でシェアボタンを押すと、`x.com/intent/post` が X アプリの Universal Link を発火し、アプリ内ブラウザに Safari セッションが無いため再ログインを強いられ、事実上シェアが完了しない問題があった。

過去対応の経緯:
- **#225 (b4e916d)**: `navigator.share` の素朴な機能検出で Web Share API に切替 → iOS は治った
- **#241 (d745e47)**: PC Chrome も `navigator.share` を露出しつつ UI が安定して開かないため、押しても無反応な副作用が発覚 → 全環境を `x.com/intent/post` に統一して**ロールバック**
- 結果、本 PR を切る直前は iPhone 側で Universal Link 経由の再ログイン問題が再発

## 観察

iPhone でも問題なく動いている他サイトを確認したところ、いずれも `/intent/tweet` パスを使っていた。

| URL | 動作 | 例 |
|---|---|---|
| `x.com/intent/post`        | ✗ Universal Link 発火、X アプリ内ブラウザで再ログイン | (現状の本プロジェクト) |
| `x.com/intent/tweet`       | ✓ Safari でそのまま投稿画面が開く | livedoor news |
| `twitter.com/intent/tweet` | ✓ Safari でそのまま投稿画面が開く | comic-action.com |

挙動を決めているのはドメインではなく**パス**で、X iOS アプリの apple-app-site-association が `x.com` の `/intent/post*` のみを Universal Link 対象にしており、旧来の `/intent/tweet` は Web 互換用エイリアスとして残っているのが原因と推測される。

## 変更内容

シェア URL のパスを `/intent/post` → `/intent/tweet` に差し替えるだけ。正規ホストは `x.com` を維持。

```diff
-setIntentUrl(`https://x.com/intent/post?${params.toString()}`)
+setIntentUrl(`https://x.com/intent/tweet?${params.toString()}`)
```

`twitter.com` 経由のリダイレクト 1 段も挟まず、PC・iPhone とも**単一コードパス**で動く。UA sniff も `navigator.share` 分岐も不要。よって:
- #225 の iPhone 再ログイン問題: 構造的に発生しない (Universal Link を踏まない)
- #241 の PC Chrome 無反応問題: 構造的に発生しない (`navigator.share` を使わない)

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` がローカルで通る (37 passed)
- [ ] iPhone Safari (実機) で `/flavor/[id]` と `/brands/[slug]` のシェアボタンを押し、Safari の新規タブで X の投稿画面が開き、ログイン済みのまま投稿できること (アプリ内ブラウザに飛ばないこと)
- [ ] PC Chrome / Firefox / Edge で従来どおり新規タブで投稿画面が開くこと
- [ ] iPad Safari でも Safari 内で開くこと

https://claude.ai/code/session_01QXzXc5TDvxwiDet6spXKkb