### PR TITLE
fix(flavor): detail image 404 — remove non-existent _w suffix

### DIFF
--- a/app/flavor/[id]/FlavorDetailClient.tsx
+++ b/app/flavor/[id]/FlavorDetailClient.tsx
@@ -39,7 +39,7 @@ export default function FlavorDetailClient({ flavor, related = [] }: FlavorDetai
             <div className="relative aspect-[3/4] md:aspect-auto md:h-full md:min-h-[640px]">
               {flavor.imageUrl ? (
                 <Image
-                  src={flavor.imageUrl.replace('.png', '_w.png')}
+                  src={flavor.imageUrl}
                   alt={`${flavor.manufacturer} ${flavor.productName} シーシャ フレーバー`}
                   fill
                   className="object-cover"


### PR DESCRIPTION
## 問題
フレーバー詳細ページ (`/flavor/[id]`) で商品画像が表示されない。
例: https://shisha-lento.com/flavor/5325 → `https://shisha-lento.com/images/flavors/5325_w.png` (404)

## 原因
`FlavorDetailClient.tsx` が `flavor.imageUrl.replace('.png', '_w.png')` で **存在しない `_w` 版**を参照していた (`8eaca51 perf: fix LCP` 由来)。
- `_w.png` 版は1枚も存在しない (git・生成スクリプトともに無し)
- フォールバック (onError) も無いため画像が完全に欠落
- `.replace('.png', ...)` は **`.png` 画像のみ**を壊す (`.jpg`/`.webp` は対象外で無事だった) → 影響 **854件**
- Must Have の新規画像が全て `.png` のため 5325 で顕在化

## 修正
置換を除去し `flavor.imageUrl` をそのまま使用。LCP は next/image の最適化で担保される。

## Validation
- `pnpm lint` ✅ / `pnpm typecheck` ✅ / `pnpm test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)