### PR TITLE
feat(picks): weekly Editor's Selection rotation helper + routine docs

### DIFF
--- a/docs/editors-selection-weekly.md
+++ b/docs/editors-selection-weekly.md
@@ -1,0 +1,38 @@
+# Editor's Selection 週次更新ルーチン
+
+トップページ § 005「Editor's Selection」(`data/curatedPicks.ts` の `EDITORS_PICKS`) を
+**毎週月曜 09:00 (JST)** にリフレッシュするクラウドルーチン。Claude エージェントが
+画像付きフレーバーから10件を再選定し、日本語短評を付け、PR を作成する（人が merge）。
+
+## 構成
+
+- **候補プール**: `pnpm picks:candidates` (`scripts/list-imaged-flavors.ts`)
+  - `public/images/flavors/<id>.<ext>` を直接走査し、画像付きフレーバーのみを出力。
+  - これに載っている id だけが選定対象 = 「画像があるフレーバーのみ」を機械的に保証。
+  - `--summary` でブランド分布、`--json` で JSON、`--local` でローカル画像限定。
+- **更新対象**: `data/curatedPicks.ts` の `EDITORS_PICKS` 配列のみ。
+- **実行基盤**: `/schedule` で作成したクラウドルーチン（cron: 毎週月曜 09:00 JST）。
+
+## ルーチンが実行するプロンプト
+
+> shisha-flavor-search リポジトリのトップページ「Editor's Selection」
+> (`data/curatedPicks.ts` の `EDITORS_PICKS`) を週次でリフレッシュする。
+>
+> 1. `main` を最新化し、新しいブランチ `chore/editors-picks-<YYYYMMDD>` を切る。
+> 2. `pnpm install` 後、`pnpm picks:candidates --summary` でブランド分布を、
+>    `pnpm picks:candidates` で候補プール（画像付きフレーバー）を取得する。
+>    **このプールに存在する id だけを選ぶ。画像が無いフレーバーは絶対に選ばない。**
+> 3. 候補から魅力的な10件を選定する。制約:
+>    - 同一ブランドは最大2件まで（ブランド多様性）
+>    - 原産国・フレーバー系統（フルーツ / ミント / デザート / タバコ感 等）を散らす
+>    - 前週 (`git log -p data/curatedPicks.ts` で確認) と全く同じ並びにしない
+> 4. 各 id に1行の日本語短評 `note`（〜40字程度、既存のトーンに合わせ、事実ベースで誇張しない）を付ける。
+> 5. `EDITORS_PICKS` 配列を新しい10件で置き換える。id は shishaData と一致させる。
+> 6. `pnpm lint && pnpm typecheck && pnpm test` を全て通す。
+> 7. commit して PR を作成。PR 本文に選定10件（id / ブランド / 製品名 / 短評）の表を載せる。
+>    **`main` へ直接 push しない。** 失敗時はエラーを報告して終了する。
+
+## メンテ
+
+- プロンプトを変えたいときは `/schedule` でこのルーチンを更新する。
+- 候補の絞り込みロジックを変えたいときは `scripts/list-imaged-flavors.ts` を編集する。

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build:data": "tsx scripts/build-data.ts",
+    "picks:candidates": "tsx scripts/list-imaged-flavors.ts",
     "dev": "pnpm run build:data && next dev",
     "prebuild": "npx tsx scripts/build/generate-flavor-image-map.ts",
     "build": "pnpm run build:data && next build",

--- a/scripts/list-imaged-flavors.ts
+++ b/scripts/list-imaged-flavors.ts
@@ -1,0 +1,104 @@
+/**
+ * List flavors that have a product image — the candidate pool for the weekly
+ * "Editor's Selection" rotation (data/curatedPicks.ts).
+ *
+ * "Has an image" means EITHER a local product shot exists at
+ * public/images/flavors/<id>.<ext> OR the flavor carries a non-empty
+ * imageUrl in shishaData. Local shots are preferred for display, so the
+ * `local` column lets the curator favour them.
+ *
+ * This scans the filesystem directly (mirroring
+ * scripts/build/generate-flavor-image-map.ts) so it has no dependency on the
+ * gitignored generated artifacts — safe to run on a fresh checkout.
+ *
+ * Usage:
+ *   pnpm picks:candidates            # TSV of every image-bearing flavor
+ *   pnpm picks:candidates --json     # JSON array instead of TSV
+ *   pnpm picks:candidates --local    # only flavors with a LOCAL image file
+ *   pnpm picks:candidates --summary  # per-brand counts (for diversity)
+ *
+ * TSV columns: id <TAB> brand <TAB> productName <TAB> country <TAB> local <TAB> image
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { shishaData } from '../data/shishaData'
+import { normalizeBrandName } from '../lib/utils/brandNormalizer'
+import type { ShishaFlavor } from '../types/shisha'
+
+const FLAVOR_IMAGES_DIR = path.join(process.cwd(), 'public', 'images', 'flavors')
+const SUPPORTED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif'])
+
+interface Candidate {
+  id: number
+  brand: string
+  productName: string
+  country: string
+  local: boolean
+  image: string
+}
+
+function localImageMap(): Map<number, string> {
+  const map = new Map<number, string>()
+  if (!fs.existsSync(FLAVOR_IMAGES_DIR)) return map
+  for (const file of fs.readdirSync(FLAVOR_IMAGES_DIR)) {
+    const ext = path.extname(file).toLowerCase()
+    if (!SUPPORTED_EXTENSIONS.has(ext)) continue
+    const id = Number(path.basename(file, ext))
+    if (!Number.isFinite(id)) continue
+    map.set(id, `/images/flavors/${file}`)
+  }
+  return map
+}
+
+function buildCandidates(localOnly: boolean): Candidate[] {
+  const local = localImageMap()
+  const out: Candidate[] = []
+  for (const flavor of shishaData as ShishaFlavor[]) {
+    const localUrl = local.get(flavor.id)
+    const externalUrl = flavor.imageUrl && flavor.imageUrl.trim() !== '' ? flavor.imageUrl.trim() : ''
+    const image = localUrl ?? externalUrl
+    if (!image) continue
+    if (localOnly && !localUrl) continue
+    out.push({
+      id: flavor.id,
+      brand: normalizeBrandName(flavor.manufacturer),
+      productName: flavor.productName,
+      country: flavor.country,
+      local: Boolean(localUrl),
+      image,
+    })
+  }
+  return out
+}
+
+function main() {
+  // Swallow EPIPE so piping into `head` etc. doesn't throw a stack trace.
+  process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EPIPE') process.exit(0)
+    throw err
+  })
+
+  const args = new Set(process.argv.slice(2))
+  const candidates = buildCandidates(args.has('--local'))
+
+  if (args.has('--summary')) {
+    const counts = new Map<string, number>()
+    for (const c of candidates) counts.set(c.brand, (counts.get(c.brand) ?? 0) + 1)
+    const rows = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    process.stderr.write(`${candidates.length} image-bearing flavors across ${rows.length} brands\n`)
+    for (const [brand, count] of rows) process.stdout.write(`${count}\t${brand}\n`)
+    return
+  }
+
+  if (args.has('--json')) {
+    process.stdout.write(`${JSON.stringify(candidates, null, 2)}\n`)
+    return
+  }
+
+  process.stderr.write(`${candidates.length} image-bearing flavors\n`)
+  for (const c of candidates) {
+    process.stdout.write(`${c.id}\t${c.brand}\t${c.productName}\t${c.country}\t${c.local ? 'local' : 'ext'}\t${c.image}\n`)
+  }
+}
+
+main()


### PR DESCRIPTION
## 概要

トップページ「Editor's Selection」(`data/curatedPicks.ts`) を**毎週月曜に自動更新**する仕組みの土台。
更新時は**画像があるフレーバーのみ**を選定対象にする、というユーザー要件を機械的に保証する。

## 変更点

- **`scripts/list-imaged-flavors.ts`** (`pnpm picks:candidates`)
  画像付きフレーバーの候補プールを出力するヘルパー。`public/images/flavors/<id>.<ext>` を
  直接走査するため、生成物 (gitignore) に依存せずフレッシュなチェックアウトで動く。
  - 既定: TSV (`id / brand / productName / country / local / image`)
  - `--summary`: ブランド別件数（多様性確認用）/ `--json`: JSON / `--local`: ローカル画像限定
  - 現在 **3,795 件**が画像付き
- **`docs/editors-selection-weekly.md`**
  毎週月曜 09:00 JST に走る `/schedule` クラウドルーチンの仕様とプロンプトを版管理。
  Claude が候補プールから10件を再選定し短評を付与 → `EDITORS_PICKS` を更新 → PR 作成（人が merge）。

## 動作確認

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm picks:candidates` / `--summary` / `--json` 出力確認 ✅

## 補足

このPRマージ後、別途 `/schedule` でクラウドルーチンを登録すると週次更新が有効化されます
（ルーチンのプロンプトは上記ドキュメントに記載）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)