### PR TITLE
fix(home): top up Latest Additions by recency (id desc), not array tail

### DIFF
--- a/data/homeSections.ts
+++ b/data/homeSections.ts
@@ -120,17 +120,13 @@ export function getLatestFlavors(limit = 6): ShishaFlavor[] {
     if (picked.length >= limit) return picked
   }
 
-  // Top up (or fall back) with image-bearing entries from the tail of data.
-  const tail = shishaData.slice(-limit * 4)
-  const imaged: ShishaFlavor[] = []
-  const rest: ShishaFlavor[] = []
-  for (let i = tail.length - 1; i >= 0; i--) {
-    const resolved = resolveFlavorImage(tail[i])
-    if (hasImage(resolved)) imaged.push(resolved)
-    else rest.push(resolved)
-  }
-  take(imaged)
-  take(rest)
+  // Top up (or fall back) with the most recently inserted flavors. IDs are
+  // assigned sequentially (max id + 1 by the update pipeline), so descending
+  // id reflects insertion order — not the array's alphabetical tail. Image-
+  // bearing first so the cards render well.
+  const byRecency = [...shishaData].sort((a, b) => b.id - a.id).map(resolveFlavorImage)
+  take(byRecency.filter(hasImage))
+  take(byRecency.filter(f => !hasImage(f)))
   return picked.slice(0, limit)
 }
 


### PR DESCRIPTION
The top-up pulled image-bearing entries from the array's alphabetical tail (the Zumerret block, ids ~5285-5294), so after the 3 newest Fumari flavors the list jumped to unrelated older entries. IDs are assigned sequentially, so sort by descending id to fill with the genuinely most recent flavors (e.g. Must Have 5334-5332) instead.