### PR TITLE
fix: アクセスログ middleware を Edge ランタイムに修正（Cloudflare デプロイ失敗の修正）

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,7 @@ const config = [
     ignores: [
       "node_modules/**",
       ".next/**",
+      ".open-next/**",
       "out/**",
       ".claude/**",
       "data/shishaData.js",

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,14 +2,21 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 /**
- * 構造化アクセスログ proxy（旧 middleware 規約。Next.js 16 で proxy にリネーム）。
+ * 構造化アクセスログ middleware（Edge ランタイム）。
  *
  * Cloudflare Workers が自動で吐く invocation log は「GET <url>」だけで情報量が乏しいため、
  * ここで 1 リクエスト = 1 行の JSON ログを追加で出力する。Cloudflare Workers Logs は
  * メッセージが JSON のとき各キーをフィールドとして取り込むので、ダッシュボードの
  * 「Fields」から ua / referer / type などを列・フィルタとして使えるようになる。
  *
- * status / 応答時間は proxy からは取得できないため対象外（取得には Worker の
+ * なぜ非推奨の `middleware` 規約か:
+ *   Next.js 16 で `proxy` 規約はデフォルトかつ強制的に Node.js ランタイムになり
+ *   （proxy ファイルで runtime を指定すると E1031 で throw する）、OpenNext / Cloudflare
+ *   Workers は Node.js middleware 非対応のためビルドが失敗する。旧 `middleware` 規約は
+ *   `runtime: 'edge'` の指定が許されるので、Edge middleware としてビルドさせて回避する。
+ *   OpenNext が Node.js middleware に対応したら proxy へ移行する。
+ *
+ * status / 応答時間は middleware からは取得できないため対象外（取得には Worker の
  * ラップが必要）。
  */
 
@@ -20,8 +27,8 @@ const BOT_PATTERN =
 /**
  * リクエストの種別を判定する。
  * 実アクセスログに大量に現れる `?_rsc=...` は RSC / プリフェッチ fetch のノイズだが、
- * Next.js は `_rsc` クエリパラメータも `RSC` / `Next-Router-Prefetch` ヘッダも proxy
- * 到達前に除去してしまう。唯一 proxy まで残る `Accept: text/x-component` で RSC を判定する。
+ * Next.js は `_rsc` クエリパラメータも `RSC` / `Next-Router-Prefetch` ヘッダも middleware
+ * 到達前に除去してしまう。唯一 middleware まで残る `Accept: text/x-component` で RSC を判定する。
  * （プリフェッチと soft navigation はヘッダが残らないため区別できない＝まとめて rsc 扱い）
  */
 function classify(request: NextRequest): 'api' | 'rsc' | 'page' {
@@ -31,7 +38,7 @@ function classify(request: NextRequest): 'api' | 'rsc' | 'page' {
   return 'page'
 }
 
-export function proxy(request: NextRequest): NextResponse {
+export function middleware(request: NextRequest): NextResponse {
   const ua = request.headers.get('user-agent') ?? ''
   const botMatch = ua.match(BOT_PATTERN)
 
@@ -56,6 +63,9 @@ export function proxy(request: NextRequest): NextResponse {
 }
 
 export const config = {
+  // Edge ランタイムを明示（Node.js middleware は OpenNext / Cloudflare 非対応のため）。
+  // Next 16 は middleware の 'edge' を弾き 'experimental-edge' を要求する。
+  runtime: 'experimental-edge',
   // 静的アセットと Next 内部パスは除外し、ページ・API・RSC のみを対象にする。
   matcher: [
     '/((?!_next/static|_next/image|favicon.ico|icon.svg|robots.txt|sitemap.xml|images/).*)',


### PR DESCRIPTION
## 背景

#365 でアクセスログ用に `proxy.ts` を追加したが、Cloudflare Workers のデプロイビルドが失敗していた:

```
ERROR Node.js middleware is not currently supported. Consider switching to Edge Middleware.
Failed: error occurred while running build command
```

## 原因

- **Next.js 16 で `proxy` 規約はデフォルトかつ強制的に Node.js ランタイム**になった（`proxy` ファイルで `runtime` を指定すると E1031 で throw／ソース確認済み）。
- **OpenNext / Cloudflare Workers は Node.js middleware に非対応**（`@opennextjs/cloudflare` 最新の 1.19.11 でも未対応）。

## 対応

1. **`proxy.ts` → `middleware.ts`(旧規約) に戻し、`runtime: 'experimental-edge'` を指定。**
   - `middleware` ファイルは `proxy` と違い `runtime` 指定が許される。
   - Next 16 は middleware の `'edge'` を弾き `'experimental-edge'` を要求するため後者を使用。
   - これで **Edge middleware** としてビルドされ（`middleware-manifest.json` の `middleware["/"]` に出る）、OpenNext のバンドルを通過する。
   - OpenNext が Node middleware に対応したら `proxy` へ移行する（コメントに明記）。
2. **eslint `ignores` に `.open-next/**` を追加。** ビルド後に `pnpm lint` すると生成物を拾って `"react plugin not defined"` で落ちるのを防ぐ。

## 検証

- ✅ `opennextjs-cloudflare build` 成功（`Node.js middleware...` エラーが消滅、`Worker saved 🚀`）
- ✅ `opennextjs-cloudflare preview`（実 workerd ランタイム）で curl 検証 — page / rsc(`text/x-component`) / api / bot(Googlebot) 判定が正しく構造化ログ出力されることを確認
- ✅ `pnpm lint`（`.open-next` 存在下でも）/ `pnpm typecheck` / `pnpm test`(37 passed)

> マージ後 `pnpm deploy` で本番反映すると、詳細アクセスログが流れ始めます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)