### PR TITLE
chore: シーシャデータ更新 (20260619 公告) — REVOSHI 2種追加

### DIFF
--- a/.claude/shisha-update-state.json
+++ b/.claude/shisha-update-state.json
@@ -1,5 +1,5 @@
 {
-  "last_run": "2026-06-21T23:52:37",
+  "last_run": "2026-06-23T20:31:54",
   "processed_pdfs": [
     "20230410_kouriteika.pdf",
     "20230419_kouriteika.pdf",
@@ -246,12 +246,12 @@
     "20260601_kouriteikahenkou.pdf",
     "20260609_kouriteika.pdf",
     "20260615_kouriteika.pdf",
-    "20260618_kouriteika.pdf"
+    "20260618_kouriteika.pdf",
+    "20260619_kouriteika.pdf"
   ],
   "last_added_ids": [
-    5335,
-    5336,
-    5337
+    5338,
+    5339
   ],
-  "last_data_updated": "2026-06-21T23:52:37"
+  "last_data_updated": "2026-06-23T20:31:54"
 }

--- a/data/shishaData.js
+++ b/data/shishaData.js
@@ -35434,6 +35434,15 @@ export const shishaData =
             "imageUrl": ""
         },
         {
+            "id": 5338,
+            "manufacturer": "REVOSHI",
+            "productName": "REVOSHI TOBACCO Pineapple Flavored",
+            "amount": "50.0g箱",
+            "country": "トルコ",
+            "price": "1,750円",
+            "imageUrl": ""
+        },
+        {
             "id": 3900,
             "manufacturer": "REVOSHI",
             "productName": "REVOSHI TOBACCO Sting Like Bee Flavored",
@@ -35563,6 +35572,15 @@ export const shishaData =
             "id": 5324,
             "manufacturer": "REVOSHI",
             "productName": "REVOSHI TOBACCO Yoghourt Flavored",
+            "amount": "50.0g箱",
+            "country": "トルコ",
+            "price": "1,750円",
+            "imageUrl": ""
+        },
+        {
+            "id": 5339,
+            "manufacturer": "REVOSHI",
+            "productName": "REVOSHI TOBACCO Yoghurt Flavored",
             "amount": "50.0g箱",
             "country": "トルコ",
             "price": "1,750円",


### PR DESCRIPTION
## 概要

財務省「製造たばこ小売定価」の新規公告 `20260619_kouriteika.pdf` を `data/shishaData.js` に反映。

## PDF 内容（パイプたばこ区分）

| ブランド | 種類 | 製品区分 | 製造国 | 小売定価 |
|---|---|---|---|---|
| JiBiAR | 9種 | 50.0g箱 | トルコ | 1,750円 |
| REVOSHI TOBACCO | 19種 | 50.0g箱 | トルコ | 1,750円 |

計28種。**うち26種は既存データの再公告**（価格据え置き=実質 no-op）。

## 新規追加（2種）

- **REVOSHI TOBACCO Yoghurt Flavored** (id 5338相当, 50.0g箱 / トルコ / 1,750円)
- **REVOSHI TOBACCO Pineapple Flavored** (50.0g箱 / トルコ / 1,750円)
  - 既存には `Eskimo PineApple` / `Sweet Pineapple` はあるが素の `Pineapple` は無く新規

総数 **5337 → 5339**（差分は18行の追加のみ、既存エントリの変更・id振り直しなし）。

## 検証

- ✅ `pnpm lint` / `npx tsc --noEmit` / `pnpm test`(37 passed)
- ✅ 新規候補2件を全既存データに対し正規化キーで照合し重複なしを確認
- ✅ 除外ブランド該当なし（JiBiAR / REVOSHI はいずれも確立済みシーシャブランド）

🤖 Generated with [Claude Code](https://claude.com/claude-code)