### PR TITLE
feat: Google Analytics (GA4) を導入

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,14 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
+import { GoogleAnalytics } from '@next/third-parties/google'
 
 import { ThemeProvider } from '../components/ThemeProvider'
 import { ThemeToggle } from '../components/ThemeToggle'
 import { escapeJsonLd } from '../lib/utils/jsonLd'
+
+// Google Analytics 4 計測 ID。クライアントに露出する公開値のため直書きで問題ない。
+const GA_MEASUREMENT_ID = 'G-1BB2YP9MYK'
 
 const geistSans = Geist({
   subsets: ['latin'],
@@ -119,6 +123,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
           {children}
         </ThemeProvider>
       </body>
+      <GoogleAnalytics gaId={GA_MEASUREMENT_ID} />
     </html>
   )
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@next/third-parties": "^16.2.9",
     "clsx": "^2.1.1",
     "fuse.js": "^7.4.2",
     "next": "^16.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.7)
+      '@next/third-parties':
+        specifier: ^16.2.9
+        version: 16.2.9(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1476,6 +1479,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@16.2.9':
+    resolution: {integrity: sha512-JZPGQRN8eQs2WMfBXOf6Zjrma+JIN0KyA24MvmIa3bUI4BwTaJ1UlxmYVc5ri6l30LQ8fPv6Kmx20447hCltrg==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -4285,6 +4294,9 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -6175,6 +6187,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.9':
     optional: true
+
+  '@next/third-parties@16.2.9(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      next: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      third-party-capital: 1.0.20
 
   '@noble/ciphers@1.3.0': {}
 
@@ -9533,6 +9551,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
+
+  third-party-capital@1.0.20: {}
 
   tinyglobby@0.2.17:
     dependencies:


### PR DESCRIPTION
## 概要

Google Analytics 4（計測 ID: `G-1BB2YP9MYK`）を導入します。

## 変更点

- `@next/third-parties` を依存に追加（Next 本体と同じ `16.2.9`）
- `app/layout.tsx` の root layout に `<GoogleAnalytics gaId="G-1BB2YP9MYK" />` を配置
  - 全ページで gtag.js を読み込み、ページビュー・クライアントサイドのルート遷移を自動計測
  - 計測 ID はクライアントに露出する公開値のため直書き（コメントで明記）

## 確認

- ✅ `pnpm lint`
- ✅ `pnpm typecheck`
- ✅ `pnpm test`（37 件パス）

## 補足

- `@next/third-parties/google` は `afterInteractive` でスクリプトを読み込むため、本番（Cloudflare Workers / `@opennextjs/cloudflare`）でもそのまま動作します。
- ローカル dev でも計測が飛びます。開発データを除外したい場合は GA 側で localhost を除外するか、env で本番のみ有効化する方式へ切り替え可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)